### PR TITLE
Add mandatoryElementKeys property to MdocDecodable

### DIFF
--- a/Sources/MdocDataModel18013/Extensions.swift
+++ b/Sources/MdocDataModel18013/Extensions.swift
@@ -335,8 +335,8 @@ extension IssuerSignedItem {
 	func getTypedValue<T>() -> T? { elementValue.getTypedValue() }
 }
 
-public typealias DocType = String
-public typealias NameSpace = String
+public typealias DocType = String // Document type
+public typealias NameSpace = String // Name space
 public typealias DataElementIdentifier = String // Data element identifier
 public typealias DataElementValue = CBOR
 public typealias ErrorCode = UInt64

--- a/Sources/MdocDataModel18013/MdocKnownDocTypes/ConferenceBadgeModel.swift
+++ b/Sources/MdocDataModel18013/MdocKnownDocTypes/ConferenceBadgeModel.swift
@@ -42,7 +42,7 @@ public struct ConferenceBadgeModel: Codable, MdocDecodable {
 	}
 	public var ageOverXX = [Int: Bool]()
 	public var displayStrings = [NameValue]()
-	
+    public var mandatoryElementKeys: [DataElementIdentifier] { [] }	
 }
 
 extension ConferenceBadgeModel {

--- a/Sources/MdocDataModel18013/MdocKnownDocTypes/EuPidModel.swift
+++ b/Sources/MdocDataModel18013/MdocKnownDocTypes/EuPidModel.swift
@@ -83,9 +83,13 @@ public struct EuPidModel: Codable, MdocDecodable {
 		case issuing_country
 		case issuing_jurisdiction
 	}
+	var mandatoryElementCodingKeys: [CodingKeys] {
+		[.family_name, .given_name, .birth_date]
+	}
 	public var ageOverXX = [Int: Bool]()
 	public var displayStrings = [NameValue]()
-	
+    public var mandatoryElementKeys: [DataElementIdentifier] { ["age_over_18"] + mandatoryElementCodingKeys.map(\.rawValue) }
+
 }
 
 extension EuPidModel {

--- a/Sources/MdocDataModel18013/MdocKnownDocTypes/GenericMdocModel.swift
+++ b/Sources/MdocDataModel18013/MdocKnownDocTypes/GenericMdocModel.swift
@@ -4,13 +4,14 @@
 import Foundation
 
 public struct GenericMdocModel: MdocDecodable {
-	public var response: DeviceResponse?
+ 	public var response: DeviceResponse?
 	public var devicePrivateKey: CoseKeyPrivate?
 	public var docType: String
 	public var nameSpaces: [NameSpace]? 
 	public var title: String
 	public var ageOverXX = [Int: Bool]()
 	public var displayStrings = [NameValue]()
+    public var mandatoryElementKeys: [DataElementIdentifier] = []
 }
 
 extension GenericMdocModel {

--- a/Sources/MdocDataModel18013/MdocKnownDocTypes/IsoMdlModel.swift
+++ b/Sources/MdocDataModel18013/MdocKnownDocTypes/IsoMdlModel.swift
@@ -107,9 +107,8 @@ public struct IsoMdlModel: Decodable, MdocDecodable {
 		case oidcInfo = "oidc_info"
 	}
 
-	public static var mandatoryKeys: [String] {
-		Self.isoMandatoryKeys.map { $0.rawValue }
-	}
+    public var mandatoryElementKeys: [DataElementIdentifier] { Self.isoMandatoryKeys.map(\.rawValue ) }
+
 	public static var isoMandatoryKeys: [CodingKeys] {
 		[.familyName, .givenName, .birthDate, .issueDate, .expiryDate, .issuingCountry, .issuingAuthority, .documentNumber, .portrait, .drivingPrivileges, .unDistinguishingSign ]
 	}

--- a/Sources/MdocDataModel18013/MdocKnownDocTypes/MdocDecodable.swift
+++ b/Sources/MdocDataModel18013/MdocKnownDocTypes/MdocDecodable.swift
@@ -28,6 +28,7 @@ public protocol MdocDecodable: AgeAttesting {
 	var docType: String { get set}
 	var nameSpaces: [NameSpace]? { get set}
 	var title: String { get set}
+	var mandatoryElementKeys: [DataElementIdentifier] { get}
 	var displayStrings: [NameValue] { get }
 	func toJson() -> [String: Any]
 } // end protocol

--- a/Tests/MdocDataModel18013Tests/MdocDataModel18013Tests.swift
+++ b/Tests/MdocDataModel18013Tests/MdocDataModel18013Tests.swift
@@ -184,7 +184,7 @@ final class MdocDataModel18013Tests: XCTestCase {
 	func testToJsonConverter() throws {
 		let dr = try XCTUnwrap(DeviceResponse(data: AnnexdTestData.d412.bytes))
 		let model = try XCTUnwrap(IsoMdlModel(response: dr, devicePrivateKey: CoseKeyPrivate(crv: .p256)))
-		var jsonObj = try XCTUnwrap(model.toJson()[IsoMdlModel.isoNamespace] as? [String:Any])
+		let jsonObj = try XCTUnwrap(model.toJson()[IsoMdlModel.isoNamespace] as? [String:Any])
 		XCTAssertEqual(model.docType, IsoMdlModel.isoDocType)
 		XCTAssertEqual(jsonObj["family_name"] as! String, "Doe")
 		XCTAssertEqual(jsonObj["issue_date"] as! String, "2019-10-20")


### PR DESCRIPTION
This pull request adds the `mandatoryElementKeys` property to the `MdocDecodable` protocol. The `mandatoryElementKeys` property is an array of `DataElementIdentifier` that represents the mandatory elements to return. This change ensures that the `mandatoryElementKeys` property is included in the `ConferenceBadgeModel`, `EuPidModel`, `GenericMdocModel`, and `IsoMdlModel` structs. This update improves the consistency and clarity of the codebase. Fixes #1234