### PR TITLE
feat: Make `msoRawData` and `deviceKeyInfo` properties public in `IssuerAuth` and `MobileSecurityObject` structs

### DIFF
--- a/Sources/MdocDataModel18013/IssuerAuth/IssuerAuth.swift
+++ b/Sources/MdocDataModel18013/IssuerAuth/IssuerAuth.swift
@@ -21,7 +21,7 @@ import SwiftCBOR
 
 public struct IssuerAuth {
 	public let mso: MobileSecurityObject
-	let msoRawData: [UInt8]
+	public let msoRawData: [UInt8]
 	/// one or more certificates
 	public let verifyAlgorithm: Cose.VerifyAlgorithm
 	public let signature: Data

--- a/Sources/MdocDataModel18013/IssuerAuth/MobileSecurityObject.swift
+++ b/Sources/MdocDataModel18013/IssuerAuth/MobileSecurityObject.swift
@@ -30,7 +30,7 @@ public struct MobileSecurityObject {
 	/// Value digests
 	public let valueDigests: ValueDigests
 	/// device key info
-	let deviceKeyInfo: DeviceKeyInfo
+	public let deviceKeyInfo: DeviceKeyInfo
 	/// docType  as used in Documents
 	public let docType: DocType
 	public let validityInfo: ValidityInfo


### PR DESCRIPTION
MobileSecurityObject may contain custom data, msoRawData access is needed