### PR TITLE
Add DisplayMetadata and LogoMetadata structures for document display properties

### DIFF
--- a/Sources/MdocDataModel18013/DocumentClaims/DisplayMetadata.swift
+++ b/Sources/MdocDataModel18013/DocumentClaims/DisplayMetadata.swift
@@ -1,0 +1,36 @@
+/*
+Copyright (c) 2023 European Commission
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import Foundation
+
+public struct DisplayMetadata: Codable, Equatable, Sendable {
+    public let name: String?
+    public let localeIdentifier: String?
+    public let logo: LogoMetadata?
+    public let description: String?
+    public let backgroundColor: String?
+    public let textColor: String?
+    public var locale: Locale? { Locale(identifier: localeIdentifier ?? "en_US") }
+    
+    public init(name: String? = nil, localeIdentifier: String? = nil, logo: LogoMetadata? = nil, description: String? = nil, backgroundColor: String? = nil, textColor: String? = nil) {
+        self.name = name
+        self.localeIdentifier = localeIdentifier
+        self.logo = logo
+        self.description = description
+        self.backgroundColor = backgroundColor
+        self.textColor = textColor
+    }
+}

--- a/Sources/MdocDataModel18013/DocumentClaims/DocClaimsDecodable.swift
+++ b/Sources/MdocDataModel18013/DocumentClaims/DocClaimsDecodable.swift
@@ -18,6 +18,7 @@ limitations under the License.
 
 import Foundation
 import SwiftCBOR
+import OpenID4VCI
 
 /// A conforming type represents claims data.
 ///
@@ -29,8 +30,12 @@ public protocol DocClaimsDecodable: Sendable, AgeAttesting {
 	var createdAt: Date { get }
 	/// The date and time the document was last modified.
 	var modifiedAt: Date? { get }
-	/// The display name of the document.
+	/// The display name of the document (derived from `display`).
 	var displayName: String? { get }
+    /// The display properties of the document
+    var display: [DisplayMetadata]? { get }
+    /// The display properties of the issuer
+    var issuerDisplay: [DisplayMetadata]? { get }
 	// The document type. For CBOR (mso_mdoc) documents is native, for SD-JWT (vc+sd-jwt) documents is the type of the document.
 	var docType: String? { get }
 	// document claims in a format agnostic way

--- a/Sources/MdocDataModel18013/DocumentClaims/DocClaimsDecodableFactory.swift
+++ b/Sources/MdocDataModel18013/DocumentClaims/DocClaimsDecodableFactory.swift
@@ -18,5 +18,7 @@ import Foundation
 
 /// A protocol to create a ``DocClaimsDecodable`` from a cbor encoded ``IssuerSigned`` struct
 public protocol DocClaimsDecodableFactory: Sendable {
-	func makeClaimsDecodableFromCbor(id: String, createdAt: Date, issuerSigned: IssuerSigned, displayName: String?, claimDisplayNames: [NameSpace: [String: String]]?, mandatoryClaims: [NameSpace: [String: Bool]]?, claimValueTypes: [NameSpace: [String: String]]?) -> (any DocClaimsDecodable)?
+    func makeClaimsDecodableFromCbor(id: String, createdAt: Date, issuerSigned: IssuerSigned, displayName: String?, display: [DisplayMetadata]?, issuerDisplay: [DisplayMetadata]?, claimDisplayNames: [NameSpace: [String: String]]?, mandatoryClaims: [NameSpace: [String: Bool]]?, claimValueTypes: [NameSpace: [String: String]]?) -> (
+        any DocClaimsDecodable
+    )?
 }

--- a/Sources/MdocDataModel18013/DocumentClaims/LogoMetadata.swift
+++ b/Sources/MdocDataModel18013/DocumentClaims/LogoMetadata.swift
@@ -1,0 +1,28 @@
+/*
+Copyright (c) 2023 European Commission
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import Foundation
+
+public struct LogoMetadata: Codable, Equatable, Sendable {
+    public let urlString: String?
+    public let alternativeText: String?
+    public var uri: URL? { urlString.flatMap(URL.init(string:)) }
+    
+    public init(urlString: String? = nil, alternativeText: String? = nil) {
+        self.urlString = urlString
+        self.alternativeText = alternativeText
+    }
+}

--- a/Sources/MdocDataModel18013/MdocKnownDocTypes/EuPidModel.swift
+++ b/Sources/MdocDataModel18013/MdocKnownDocTypes/EuPidModel.swift
@@ -19,6 +19,8 @@ limitations under the License.
 import Foundation
 
 public struct EuPidModel: Decodable, DocClaimsDecodable, Sendable {
+    public var display: [DisplayMetadata]?
+    public var issuerDisplay: [DisplayMetadata]?
 	public static let euPidDocType: String = "eu.europa.ec.eudi.pid.1"
 	public var id: String = UUID().uuidString
 	public var createdAt: Date = Date()
@@ -95,9 +97,9 @@ public struct EuPidModel: Decodable, DocClaimsDecodable, Sendable {
 }
 
 extension EuPidModel {
-	public init?(id: String, createdAt: Date, issuerSigned: IssuerSigned, displayName: String?, claimDisplayNames: [NameSpace: [String: String]]?, mandatoryClaims: [NameSpace: [String: Bool]]?, claimValueTypes: [NameSpace: [String: String]]?) {
+	public init?(id: String, createdAt: Date, issuerSigned: IssuerSigned, displayName: String?, display: [DisplayMetadata]?, issuerDisplay: [DisplayMetadata]?, claimDisplayNames: [NameSpace: [String: String]]?, mandatoryClaims: [NameSpace: [String: Bool]]?, claimValueTypes: [NameSpace: [String: String]]?) {
 		self.id = id
-		self.createdAt = createdAt;	self.displayName = displayName
+        self.createdAt = createdAt;	self.displayName = displayName; self.display = display; self.issuerDisplay = issuerDisplay
 		guard let nameSpaces = Self.getCborSignedItems(issuerSigned) else { return nil }
 		Self.extractCborClaims(nameSpaces, &docClaims, claimDisplayNames, mandatoryClaims, claimValueTypes)
 		Self.extractAgeOverValues(nameSpaces, &ageOverXX)

--- a/Sources/MdocDataModel18013/MdocKnownDocTypes/GenericMdocModel.swift
+++ b/Sources/MdocDataModel18013/MdocKnownDocTypes/GenericMdocModel.swift
@@ -4,6 +4,8 @@
 import Foundation
 
 public struct GenericMdocModel: DocClaimsDecodable, Sendable {
+    public var display: [DisplayMetadata]?
+    public var issuerDisplay: [DisplayMetadata]?
 	public var id: String = UUID().uuidString
 	public var createdAt: Date = Date()
 	public var docType: String?
@@ -12,12 +14,14 @@ public struct GenericMdocModel: DocClaimsDecodable, Sendable {
 	public var ageOverXX = [Int: Bool]()
 	public var docClaims = [DocClaim]()
     public var docDataFormat: DocDataFormat
+    public var hashingAlg: String?
 
-    public init(id: String = UUID().uuidString, createdAt: Date = Date(), docType: String? = nil, displayName: String? = nil, modifiedAt: Date? = nil, ageOverXX: [Int : Bool] = [Int: Bool](), docClaims: [DocClaim] = [DocClaim](), docDataFormat: DocDataFormat = .cbor) {
+    public init(id: String = UUID().uuidString, createdAt: Date = Date(), docType: String? = nil, displayName: String? = nil, display: [DisplayMetadata]? = nil, issuerDisplay: [DisplayMetadata]? = nil, modifiedAt: Date? = nil, ageOverXX: [Int : Bool] = [Int: Bool](), docClaims: [DocClaim] = [DocClaim](), docDataFormat: DocDataFormat = .cbor, hashingAlg: String? = nil) {
         self.id = id
         self.createdAt = createdAt
         self.docType = docType
         self.displayName = displayName
+        self.display = display; self.issuerDisplay = issuerDisplay
         self.modifiedAt = modifiedAt
         self.ageOverXX = ageOverXX
         self.docClaims = docClaims
@@ -27,8 +31,10 @@ public struct GenericMdocModel: DocClaimsDecodable, Sendable {
 
 extension GenericMdocModel {
 
-	public init?(id: String, createdAt: Date, issuerSigned: IssuerSigned, docType: String, displayName: String?, claimDisplayNames: [NameSpace: [String: String]]?, mandatoryClaims: [NameSpace: [String: Bool]]?, claimValueTypes: [NameSpace: [String: String]]?) {
-		self.id = id; self.createdAt = createdAt; self.displayName = displayName; self.docType = docType; self.docDataFormat = .cbor
+	public init?(id: String, createdAt: Date, issuerSigned: IssuerSigned, docType: String, displayName: String?, display: [DisplayMetadata]?, issuerDisplay: [DisplayMetadata]?, claimDisplayNames: [NameSpace: [String: String]]?, mandatoryClaims: [NameSpace: [String: Bool]]?, claimValueTypes: [NameSpace: [String: String]]?) {
+        self.id = id; self.createdAt = createdAt; self.displayName = displayName
+        self.display = display; self.issuerDisplay = issuerDisplay
+        self.docType = docType; self.docDataFormat = .cbor
 		if let nameSpaces = Self.getCborSignedItems(issuerSigned) {
 			Self.extractCborClaims(nameSpaces, &docClaims, claimDisplayNames, mandatoryClaims, claimValueTypes)
 		}

--- a/Sources/MdocDataModel18013/MdocKnownDocTypes/IsoMdlModel.swift
+++ b/Sources/MdocDataModel18013/MdocKnownDocTypes/IsoMdlModel.swift
@@ -19,6 +19,8 @@ limitations under the License.
 import Foundation
 
 public struct IsoMdlModel: Decodable, DocClaimsDecodable, Sendable {
+    public var display: [DisplayMetadata]?
+    public var issuerDisplay: [DisplayMetadata]?
 	public var id: String = UUID().uuidString
 	public var createdAt: Date = Date()
 	public var docType: String? = Self.isoDocType
@@ -119,8 +121,8 @@ public struct IsoMdlModel: Decodable, DocClaimsDecodable, Sendable {
 
 
 extension IsoMdlModel {
-	public init?(id: String, createdAt: Date, issuerSigned: IssuerSigned, displayName: String?, claimDisplayNames: [NameSpace: [String: String]]?, mandatoryClaims: [NameSpace: [String: Bool]]?, claimValueTypes: [NameSpace: [String: String]]?) {
-		self.id = id; self.createdAt = createdAt; self.displayName = displayName
+	public init?(id: String, createdAt: Date, issuerSigned: IssuerSigned, displayName: String?, display: [DisplayMetadata]?, issuerDisplay: [DisplayMetadata]?, claimDisplayNames: [NameSpace: [String: String]]?, mandatoryClaims: [NameSpace: [String: Bool]]?, claimValueTypes: [NameSpace: [String: String]]?) {
+        self.id = id; self.createdAt = createdAt; self.displayName = displayName; self.display = display; self.issuerDisplay = issuerDisplay
   	    guard let nameSpaceItems = Self.getCborSignedItems(issuerSigned, nameSpaces) else { return nil }
 		Self.extractCborClaims(nameSpaceItems, &docClaims, claimDisplayNames, mandatoryClaims, claimValueTypes)
 		func getValue<T>(key: IsoMdlModel.CodingKeys) -> T? { Self.getCborItemValue(nameSpaceItems, string: key.rawValue) }


### PR DESCRIPTION
Introduce DisplayMetadata and LogoMetadata structures to enhance document display properties. Update DocClaimsDecodable to include these new display attributes.