### PR TITLE
Add validFrom and validUntil properties to DocClaimsDecodable models

### DIFF
--- a/Sources/MdocDataModel18013/DocumentClaims/DocClaimsDecodable.swift
+++ b/Sources/MdocDataModel18013/DocumentClaims/DocClaimsDecodable.swift
@@ -45,6 +45,10 @@ public protocol DocClaimsDecodable: Sendable, AgeAttesting {
 	var docClaims: [DocClaim] { get }
     /// The format of the document data.
     var docDataFormat: DocDataFormat { get }
+    /// Valid from date
+    var validFrom: Date? { get }
+    /// Valid until date
+    var validUntil: Date? { get }
 } // end protocol
 
 /// Methods to extract CBOR values.

--- a/Sources/MdocDataModel18013/DocumentClaims/DocClaimsDecodableFactory.swift
+++ b/Sources/MdocDataModel18013/DocumentClaims/DocClaimsDecodableFactory.swift
@@ -18,7 +18,7 @@ import Foundation
 
 /// A protocol to create a ``DocClaimsDecodable`` from a cbor encoded ``IssuerSigned`` struct
 public protocol DocClaimsDecodableFactory: Sendable {
-    func makeClaimsDecodableFromCbor(id: String, createdAt: Date, issuerSigned: IssuerSigned, displayName: String?, display: [DisplayMetadata]?, issuerDisplay: [DisplayMetadata]?, credentialIssuerIdentifier: String?, configurationIdentifier: String?, claimDisplayNames: [NameSpace: [String: String]]?, mandatoryClaims: [NameSpace: [String: Bool]]?, claimValueTypes: [NameSpace: [String: String]]?) -> (
+    func makeClaimsDecodableFromCbor(id: String, createdAt: Date, issuerSigned: IssuerSigned, displayName: String?, display: [DisplayMetadata]?, issuerDisplay: [DisplayMetadata]?, credentialIssuerIdentifier: String?, configurationIdentifier: String?, validFrom: Date?, validUntil: Date?, claimDisplayNames: [NameSpace: [String: String]]?, mandatoryClaims: [NameSpace: [String: Bool]]?, claimValueTypes: [NameSpace: [String: String]]?) -> (
         any DocClaimsDecodable
     )?
 }

--- a/Sources/MdocDataModel18013/Extensions.swift
+++ b/Sources/MdocDataModel18013/Extensions.swift
@@ -382,3 +382,9 @@ public typealias ErrorCode = UInt64
 public typealias DigestID = UInt64
 
 public class BundleClass {}
+
+let usDateFormatter: DateFormatter = {
+    let df = DateFormatter()
+    df.dateFormat = "yyyy-MM-dd"
+    return df
+}()

--- a/Sources/MdocDataModel18013/MdocKnownDocTypes/EuPidModel.swift
+++ b/Sources/MdocDataModel18013/MdocKnownDocTypes/EuPidModel.swift
@@ -31,6 +31,8 @@ public struct EuPidModel: Decodable, DocClaimsDecodable, Sendable {
     public var docDataFormat: DocDataFormat = .cbor
     public var credentialIssuerIdentifier: String?
     public var configurationIdentifier: String?
+    public var validFrom: Date?
+    public var validUntil: Date?
 	public let family_name: String?
 	public let given_name: String?
 	public let birth_date: String?
@@ -100,10 +102,11 @@ public struct EuPidModel: Decodable, DocClaimsDecodable, Sendable {
 }
 
 extension EuPidModel {
-	public init?(id: String, createdAt: Date, issuerSigned: IssuerSigned, displayName: String?, display: [DisplayMetadata]?, issuerDisplay: [DisplayMetadata]?, credentialIssuerIdentifier: String?, configurationIdentifier: String?, claimDisplayNames: [NameSpace: [String: String]]?, mandatoryClaims: [NameSpace: [String: Bool]]?, claimValueTypes: [NameSpace: [String: String]]?) {
+	public init?(id: String, createdAt: Date, issuerSigned: IssuerSigned, displayName: String?, display: [DisplayMetadata]?, issuerDisplay: [DisplayMetadata]?, credentialIssuerIdentifier: String?, configurationIdentifier: String?, validFrom: Date?, validUntil: Date?, claimDisplayNames: [NameSpace: [String: String]]?, mandatoryClaims: [NameSpace: [String: Bool]]?, claimValueTypes: [NameSpace: [String: String]]?) {
 		self.id = id
         self.createdAt = createdAt;	self.displayName = displayName; self.display = display; self.issuerDisplay = issuerDisplay
         self.credentialIssuerIdentifier = credentialIssuerIdentifier; self.configurationIdentifier = configurationIdentifier
+        self.validFrom = validFrom; self.validUntil = validUntil
 		guard let nameSpaces = Self.getCborSignedItems(issuerSigned) else { return nil }
 		Self.extractCborClaims(nameSpaces, &docClaims, claimDisplayNames, mandatoryClaims, claimValueTypes)
 		Self.extractAgeOverValues(nameSpaces, &ageOverXX)

--- a/Sources/MdocDataModel18013/MdocKnownDocTypes/GenericMdocModel.swift
+++ b/Sources/MdocDataModel18013/MdocKnownDocTypes/GenericMdocModel.swift
@@ -8,6 +8,8 @@ public struct GenericMdocModel: DocClaimsDecodable, Sendable {
     public var issuerDisplay: [DisplayMetadata]?
     public var credentialIssuerIdentifier: String?
     public var configurationIdentifier: String?
+    public var validFrom: Date?
+    public var validUntil: Date?
 	public var id: String = UUID().uuidString
 	public var createdAt: Date = Date()
 	public var docType: String?
@@ -18,7 +20,7 @@ public struct GenericMdocModel: DocClaimsDecodable, Sendable {
     public var docDataFormat: DocDataFormat
     public var hashingAlg: String?
 
-    public init(id: String = UUID().uuidString, createdAt: Date = Date(), docType: String?, displayName: String?, display: [DisplayMetadata]?, issuerDisplay: [DisplayMetadata]? = nil, credentialIssuerIdentifier: String?, configurationIdentifier: String?, modifiedAt: Date?, ageOverXX: [Int : Bool] = [Int: Bool](), docClaims: [DocClaim] = [DocClaim](), docDataFormat: DocDataFormat, hashingAlg: String?) {
+    public init(id: String = UUID().uuidString, createdAt: Date = Date(), docType: String?, displayName: String?, display: [DisplayMetadata]?, issuerDisplay: [DisplayMetadata]? = nil, credentialIssuerIdentifier: String?, configurationIdentifier: String?, validFrom: Date?, validUntil: Date?, modifiedAt: Date?, ageOverXX: [Int : Bool] = [Int: Bool](), docClaims: [DocClaim] = [DocClaim](), docDataFormat: DocDataFormat, hashingAlg: String?) {
         self.id = id
         self.createdAt = createdAt
         self.docType = docType
@@ -26,6 +28,8 @@ public struct GenericMdocModel: DocClaimsDecodable, Sendable {
         self.display = display; self.issuerDisplay = issuerDisplay
         self.credentialIssuerIdentifier = credentialIssuerIdentifier
         self.configurationIdentifier = configurationIdentifier
+        self.validFrom = validFrom
+        self.validUntil = validUntil
         self.modifiedAt = modifiedAt
         self.ageOverXX = ageOverXX
         self.docClaims = docClaims
@@ -35,10 +39,11 @@ public struct GenericMdocModel: DocClaimsDecodable, Sendable {
 
 extension GenericMdocModel {
 
-	public init?(id: String, createdAt: Date, issuerSigned: IssuerSigned, docType: String, displayName: String?, display: [DisplayMetadata]?, issuerDisplay: [DisplayMetadata]?, credentialIssuerIdentifier: String?, configurationIdentifier: String?, claimDisplayNames: [NameSpace: [String: String]]?, mandatoryClaims: [NameSpace: [String: Bool]]?, claimValueTypes: [NameSpace: [String: String]]?) {
+	public init?(id: String, createdAt: Date, issuerSigned: IssuerSigned, docType: String, displayName: String?, display: [DisplayMetadata]?, issuerDisplay: [DisplayMetadata]?, credentialIssuerIdentifier: String?, configurationIdentifier: String?, validFrom: Date?, validUntil: Date?, claimDisplayNames: [NameSpace: [String: String]]?, mandatoryClaims: [NameSpace: [String: Bool]]?, claimValueTypes: [NameSpace: [String: String]]?) {
         self.id = id; self.createdAt = createdAt; self.displayName = displayName
         self.display = display; self.issuerDisplay = issuerDisplay
         self.credentialIssuerIdentifier = credentialIssuerIdentifier; self.configurationIdentifier = configurationIdentifier
+        self.validFrom = validFrom; self.validUntil = validUntil
         self.docType = docType; self.docDataFormat = .cbor
 		if let nameSpaces = Self.getCborSignedItems(issuerSigned) {
 			Self.extractCborClaims(nameSpaces, &docClaims, claimDisplayNames, mandatoryClaims, claimValueTypes)

--- a/Sources/MdocDataModel18013/MdocKnownDocTypes/IsoMdlModel.swift
+++ b/Sources/MdocDataModel18013/MdocKnownDocTypes/IsoMdlModel.swift
@@ -23,6 +23,8 @@ public struct IsoMdlModel: Decodable, DocClaimsDecodable, Sendable {
     public var issuerDisplay: [DisplayMetadata]?
     public var credentialIssuerIdentifier: String?
     public var configurationIdentifier: String?
+    public var validFrom: Date?
+    public var validUntil: Date?
 	public var id: String = UUID().uuidString
 	public var createdAt: Date = Date()
 	public var docType: String? = Self.isoDocType
@@ -125,9 +127,10 @@ public struct IsoMdlModel: Decodable, DocClaimsDecodable, Sendable {
 
 
 extension IsoMdlModel {
-	public init?(id: String, createdAt: Date, issuerSigned: IssuerSigned, displayName: String?, display: [DisplayMetadata]?, issuerDisplay: [DisplayMetadata]?, credentialIssuerIdentifier: String?, configurationIdentifier: String?, claimDisplayNames: [NameSpace: [String: String]]?, mandatoryClaims: [NameSpace: [String: Bool]]?, claimValueTypes: [NameSpace: [String: String]]?) {
+	public init?(id: String, createdAt: Date, issuerSigned: IssuerSigned, displayName: String?, display: [DisplayMetadata]?, issuerDisplay: [DisplayMetadata]?, credentialIssuerIdentifier: String?, configurationIdentifier: String?, validFrom: Date?, validUntil: Date?, claimDisplayNames: [NameSpace: [String: String]]?, mandatoryClaims: [NameSpace: [String: Bool]]?, claimValueTypes: [NameSpace: [String: String]]?) {
         self.id = id; self.createdAt = createdAt; self.displayName = displayName; self.display = display; self.issuerDisplay = issuerDisplay
         self.credentialIssuerIdentifier = credentialIssuerIdentifier; self.configurationIdentifier = configurationIdentifier
+        self.validFrom = validFrom; self.validUntil = validUntil
   	    guard let nameSpaceItems = Self.getCborSignedItems(issuerSigned, nameSpaces) else { return nil }
 		Self.extractCborClaims(nameSpaceItems, &docClaims, claimDisplayNames, mandatoryClaims, claimValueTypes)
 		func getValue<T>(key: IsoMdlModel.CodingKeys) -> T? { Self.getCborItemValue(nameSpaceItems, string: key.rawValue) }

--- a/Sources/MdocDataModel18013/MdocResponse/IssuerSigned.swift
+++ b/Sources/MdocDataModel18013/MdocResponse/IssuerSigned.swift
@@ -51,4 +51,16 @@ extension IssuerSigned: CBOREncodable {
 	}
 }
 
-
+extension IssuerSigned {
+    public var validFrom: Date? {
+        let usDateStr = issuerAuth.mso.validityInfo.validFrom.usPosixDate()
+        let df = usDateFormatter
+        return df.date(from: usDateStr)
+    }
+    
+    public var validUntil: Date? {
+        let usDateStr = issuerAuth.mso.validityInfo.validUntil.usPosixDate()
+        let df = usDateFormatter
+        return df.date(from: usDateStr)
+    }
+}

--- a/Tests/MdocDataModel18013Tests/MdocDataModel18013Tests.swift
+++ b/Tests/MdocDataModel18013Tests/MdocDataModel18013Tests.swift
@@ -95,9 +95,9 @@ final class MdocDataModel18013Tests: XCTestCase {
 	  	let d1 = try XCTUnwrap(docs.first(where: {$0.docType == EuPidModel.euPidDocType}))
 		let d2 = try XCTUnwrap(docs.first(where: {$0.docType == IsoMdlModel.isoDocType}))
 		//let ns1 = d1?.issuerSigned.issuerNameSpaces!.nameSpaces.first
-		let pidObj = try XCTUnwrap(EuPidModel(id: UUID().uuidString, createdAt: Date(), issuerSigned: d1.issuerSigned, displayName: nil, claimDisplayNames: nil, mandatoryClaims: nil, claimValueTypes: nil))
+		let pidObj = try XCTUnwrap(EuPidModel(id: UUID().uuidString, createdAt: Date(), issuerSigned: d1.issuerSigned, displayName: "PID", display: nil, issuerDisplay: nil, credentialIssuerIdentifier: nil, configurationIdentifier: nil, validFrom: d1.issuerSigned.validFrom, validUntil: d1.issuerSigned.validUntil, claimDisplayNames: nil, mandatoryClaims: nil, claimValueTypes: nil))
 		XCTAssertEqual(pidObj.family_name, "ANDERSSON")
-		let mdlObj = try XCTUnwrap(IsoMdlModel(id: UUID().uuidString, createdAt: Date(), issuerSigned: d2.issuerSigned, displayName: nil, claimDisplayNames: nil, mandatoryClaims: nil, claimValueTypes: nil))
+		let mdlObj = try XCTUnwrap(IsoMdlModel(id: UUID().uuidString, createdAt: Date(), issuerSigned: d2.issuerSigned, displayName: "mDL", display: nil, issuerDisplay: nil, credentialIssuerIdentifier: nil, configurationIdentifier: nil, validFrom: d1.issuerSigned.validFrom, validUntil: d1.issuerSigned.validUntil, claimDisplayNames: nil, mandatoryClaims: nil, claimValueTypes: nil))
 		XCTAssertEqual(mdlObj.familyName, "ANDERSSON")
 		printDisplayStrings(mdlObj.docClaims)
 	}
@@ -138,7 +138,8 @@ final class MdocDataModel18013Tests: XCTestCase {
 		XCTAssertEqual(doc.deviceSigned?.nameSpacesRawData.count, 1); XCTAssertEqual(doc.deviceSigned?.nameSpacesRawData[0], 160) // {} A0 empty dic
 		XCTAssertEqual(doc.deviceSigned?.deviceAuth.coseMacOrSignature.macAlgorithm, Cose.MacAlgorithm.hmac256)
 		XCTAssertEqual(doc.deviceSigned?.deviceAuth.coseMacOrSignature.signature.bytes.toHexString().uppercased(), "E99521A85AD7891B806A07F8B5388A332D92C189A7BF293EE1F543405AE6824D")
-		let model = try XCTUnwrap(IsoMdlModel(id: UUID().uuidString, createdAt: Date(), issuerSigned: dr.documents!.first!.issuerSigned, displayName: nil, claimDisplayNames: nil, mandatoryClaims: nil, claimValueTypes: nil))
+        let d1 = dr.documents!.first!
+		let model = try XCTUnwrap(IsoMdlModel(id: UUID().uuidString, createdAt: Date(), issuerSigned: d1.issuerSigned, displayName: "PID", display: nil, issuerDisplay: nil, credentialIssuerIdentifier: nil, configurationIdentifier: nil, validFrom: d1.issuerSigned.validFrom, validUntil: d1.issuerSigned.validUntil, claimDisplayNames: nil, mandatoryClaims: nil, claimValueTypes: nil))
 		XCTAssertEqual(model.familyName, "Doe")
 	}
 


### PR DESCRIPTION
Introduce `validFrom` and `validUntil` properties to the `DocClaimsDecodable` protocol and related models to enhance date validity tracking for document claims. Update initializers and methods accordingly to accommodate these new properties.