### PR TITLE
Fix wrongful usage of Bluetooth Base UUID

### DIFF
--- a/Sources/MdocDataModel18013/DeviceEngagement/DeviceEngagement.swift
+++ b/Sources/MdocDataModel18013/DeviceEngagement/DeviceEngagement.swift
@@ -58,7 +58,7 @@ public struct DeviceEngagement: Sendable {
 	///    - crv: The EC curve type used in the mdoc ephemeral private key
     public init?(isBleServer: Bool?, rfus: [String]? = nil) {
 		self.rfus = rfus
-		if let isBleServer { deviceRetrievalMethods = [.ble(isBleServer: isBleServer, uuid: DeviceRetrievalMethod.getRandomBleUuid())] }
+        if let isBleServer { deviceRetrievalMethods = [.ble(isBleServer: isBleServer, uuid: UUID().uuidString)] }
 	}
 	/// initialize from cbor data
 	public init?(data: [UInt8]) {

--- a/Sources/MdocDataModel18013/DeviceEngagement/DeviceEngagement.swift
+++ b/Sources/MdocDataModel18013/DeviceEngagement/DeviceEngagement.swift
@@ -58,7 +58,7 @@ public struct DeviceEngagement: Sendable {
 	///    - crv: The EC curve type used in the mdoc ephemeral private key
     public init?(isBleServer: Bool?, rfus: [String]? = nil) {
 		self.rfus = rfus
-        if let isBleServer { deviceRetrievalMethods = [.ble(isBleServer: isBleServer, uuid: UUID().uuidString)] }
+        if let isBleServer { deviceRetrievalMethods = [.ble(isBleServer: isBleServer, uuid: UUID())] }
 	}
 	/// initialize from cbor data
 	public init?(data: [UInt8]) {
@@ -84,7 +84,7 @@ public struct DeviceEngagement: Sendable {
 	public var ble_uuid: String? {
 		guard let deviceRetrievalMethods else { return nil}
 		for case let .ble(_, uuid) in deviceRetrievalMethods {
-			return uuid
+            return uuid.uuidString
 		}
 		return nil
 	}

--- a/Sources/MdocDataModel18013/DeviceEngagement/DeviceRetrievalMethod.swift
+++ b/Sources/MdocDataModel18013/DeviceEngagement/DeviceRetrievalMethod.swift
@@ -29,13 +29,6 @@ public enum DeviceRetrievalMethod: Equatable, Sendable {
     case nfc(maxLenCommand: UInt64, maxLenResponse: UInt64)
     case ble(isBleServer: Bool, uuid: String)
     //  case wifiaware // not supported in ios
-    static let BASE_UUID_SUFFIX_SERVICE = "-0000-1000-8000-00805F9B34FB".replacingOccurrences(of: "-", with: "")
-    static func getRandomBleUuid() -> String {
-        let uuidFull = UUID().uuidString.replacingOccurrences(of: "-", with: "")
-        let index = uuidFull.index(uuidFull.startIndex, offsetBy: 4)
-        let uuid = String(uuidFull[index...].prefix(4))
-        return "0000\(uuid)\(BASE_UUID_SUFFIX_SERVICE)"
-    }
 }
 
 extension DeviceRetrievalMethod: CBOREncodable {
@@ -53,7 +46,7 @@ extension DeviceRetrievalMethod: CBOREncodable {
             cborArr.append(options)
         case .ble(let isBleServer, let uuid):
             Self.appendTypeAndVersion(&cborArr, type: 2)
-            let options: CBOR = [0: .boolean(isBleServer), 1: .boolean(!isBleServer), .unsignedInt(isBleServer ? 10 : 11): .byteString(uuid.byteArray)]
+            let options: CBOR = [0: .boolean(isBleServer), 1: .boolean(!isBleServer), .unsignedInt(isBleServer ? 10 : 11): .byteString(uuid.replacingOccurrences(of: "-", with: "").byteArray)]
             cborArr.append(options)
         }
         return .array(cborArr)

--- a/Sources/MdocDataModel18013/Extensions.swift
+++ b/Sources/MdocDataModel18013/Extensions.swift
@@ -80,6 +80,14 @@ extension String {
 	}
 }
 
+extension UUID {
+    init?(uuidBytes: [UInt8]) {
+        let nsUUIDString = UUID.ReferenceType(uuidBytes: uuidBytes).uuidString
+        guard let uuid = UUID(uuidString: nsUUIDString) else { return nil }
+        self = uuid
+    }
+}
+
 extension Data {
 	public var bytes: Array<UInt8> {
 		Array(self)


### PR DESCRIPTION
The Bluetooth Base UUID  eg `-0000-1000-8000-00805F9B34FB` should only be used for Assigned Numbers.

See `Bluetooth Core Specification` - `SERVICE DISCOVERY PROTOCOL (SDP) SPECIFICATION` - `2.5.1 UUID`
https://www.bluetooth.org/docman/handlers/downloaddoc.ashx?doc_id=478726

> 2.5.1 UUID
>
> A UUID is a universally unique identifier that is guaranteed to be unique across all space and all time. UUIDs can be independently created in a distributed fashion. No central registry of assigned UUIDs is required. A UUID is a 128-bit value.
>
> To reduce the burden of storing and transferring 128-bit UUID values, a range of UUID values has been pre-allocated for assignment to often-used, registered purposes. The first UUID in this pre-allocated range is known as the Bluetooth Base UUID and has the value 00000000-0000-1000-8000- 00805F9B34FB, from **_Assigned Numbers_**. UUID values in the **_pre-allocated range_** have aliases that are represented as 16-bit or 32-bit values. These aliases are often called 16-bit and 32-bit UUIDs, but each actually represents a 128-bit UUID value.

ISO18013-5 should not use Assigned Numbers as their service UUID, as it does not regard `Wearable Headset Devices`, `Remote Controls`, `Blood Pressure Monitors` or any of the other predefined categories.

Chapter "8.3.3.1.1.3 Connection setup" of ISO18013-5 first and second edition states:
> "The UUID's used shall be 16-byte UUIDs that are unique for the transaction. The Peripheral device shall broadcast the service with the UUID as received or sent during device engagement in the advertising packet."

To reduce the risk of collision, the entire 128bits of the UUID should be random.
