### PR TITLE
Add DocClaimMetadata struct and license headers

### DIFF
--- a/Sources/MdocDataModel18013/DocumentClaims/DocClaimMetadata.swift
+++ b/Sources/MdocDataModel18013/DocumentClaims/DocClaimMetadata.swift
@@ -1,0 +1,29 @@
+/*
+Copyright (c) 2023 European Commission
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import Foundation
+
+@DebugDescription
+public struct DocClaimMetadata: Sendable, Codable, CustomStringConvertible, CustomDebugStringConvertible {
+	public func getDisplayName(_ uiCulture: String?) -> String? { display?.getName(uiCulture) }
+	public let display: [DisplayMetadata]?
+	public let isMandatory: Bool?
+	public let claimPath: [String]
+	/// Description of the claim.
+	public var description: String { "\(claimPath)" }
+	/// Debug description of the claim.
+	public var debugDescription: String { "\(claimPath)" }
+}

--- a/Sources/MdocDataModel18013/DocumentClaims/DocDataFormat.swift
+++ b/Sources/MdocDataModel18013/DocumentClaims/DocDataFormat.swift
@@ -1,3 +1,19 @@
+/*
+Copyright (c) 2023 European Commission
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 import Foundation
 /// Format of document data
 /// ``cbor``: IssuerSigned struct cbor encoded

--- a/Sources/MdocDataModel18013/DocumentClaims/DocMetadata.swift
+++ b/Sources/MdocDataModel18013/DocumentClaims/DocMetadata.swift
@@ -1,3 +1,19 @@
+/*
+Copyright (c) 2023 European Commission
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 import Foundation
 
 public struct DocMetadata: Sendable, Codable {
@@ -43,15 +59,3 @@ public struct DocMetadata: Sendable, Codable {
 	}
 }
 
-public struct DocClaimMetadata: Sendable, Codable {
-    public init(display: [DisplayMetadata]?, isMandatory: Bool?, valueType: String? = nil) {
-        self.display = display
-        self.isMandatory = isMandatory
-        self.valueType = valueType
-    }
-
-	public func getDisplayName(_ uiCulture: String?) -> String? { display?.getName(uiCulture) }
-	public let display: [DisplayMetadata]?
-	public let isMandatory: Bool?
-	public let valueType: String?
-}

--- a/Sources/MdocDataModel18013/DocumentClaims/LogoMetadata.swift
+++ b/Sources/MdocDataModel18013/DocumentClaims/LogoMetadata.swift
@@ -20,7 +20,7 @@ public struct LogoMetadata: Codable, Equatable, Sendable {
     public let urlString: String?
     public let alternativeText: String?
     public var uri: URL? { urlString.flatMap(URL.init(string:)) }
-    
+
     public init(urlString: String? = nil, alternativeText: String? = nil) {
         self.urlString = urlString
         self.alternativeText = alternativeText


### PR DESCRIPTION
Introduce the `DocClaimMetadata` struct for representing document claims. Add missing license headers to `DocDataFormat`, `DocMetadata`, and `LogoMetadata` files to ensure compliance.