### PR TITLE
Refactor DocMetadata and date handling improvements

### DIFF
--- a/Sources/MdocDataModel18013/DocumentClaims/DocClaimMetadata.swift
+++ b/Sources/MdocDataModel18013/DocumentClaims/DocClaimMetadata.swift
@@ -18,6 +18,12 @@ import Foundation
 
 @DebugDescription
 public struct DocClaimMetadata: Sendable, Codable, CustomStringConvertible, CustomDebugStringConvertible {
+    public init(display: [DisplayMetadata]?, isMandatory: Bool?, claimPath: [String]) {
+        self.display = display
+        self.isMandatory = isMandatory
+        self.claimPath = claimPath
+}
+
 	public func getDisplayName(_ uiCulture: String?) -> String? { display?.getName(uiCulture) }
 	public let display: [DisplayMetadata]?
 	public let isMandatory: Bool?

--- a/Sources/MdocDataModel18013/DocumentClaims/DocMetadata.swift
+++ b/Sources/MdocDataModel18013/DocumentClaims/DocMetadata.swift
@@ -29,22 +29,18 @@ public struct DocMetadata: Sendable, Codable {
 	public let display: [DisplayMetadata]?
 	/// display properties of the issuer that issued the document
 	public let issuerDisplay: [DisplayMetadata]?
-		/// get display name of the issuer for the given culture
-	 public func getIssuerDisplayName(_ uiCulture: String?) -> String? { issuerDisplay?.getName(uiCulture) }
+	/// get display name of the issuer for the given culture
+	public func getIssuerDisplayName(_ uiCulture: String?) -> String? { issuerDisplay?.getName(uiCulture) }
+	/// claims (for mso-mdoc and sd-jwt documents)
+	public let claims: [DocClaimMetadata]?
 
-	/// namespaced claims (for sd-jwt documents)
-	public let namespacedClaims: [NameSpace: [String: DocClaimMetadata]]?
-	/// flat claims (for mso-mdoc documents)
-	public let flatClaims: [String: DocClaimMetadata]?
-
-	public init(credentialIssuerIdentifier: String, configurationIdentifier: String, docType: String?, display: [DisplayMetadata]?, issuerDisplay: [DisplayMetadata]?, namespacedClaims: [NameSpace: [String: DocClaimMetadata]]? = nil, flatClaims: [String: DocClaimMetadata]? = nil) {
+	public init(credentialIssuerIdentifier: String, configurationIdentifier: String, docType: String?, display: [DisplayMetadata]?, issuerDisplay: [DisplayMetadata]?, claims: [DocClaimMetadata]? = nil) {
 		self.credentialIssuerIdentifier = credentialIssuerIdentifier
 		self.configurationIdentifier = configurationIdentifier
 		self.docType = docType
 		self.display = display
 		self.issuerDisplay = issuerDisplay
-		self.namespacedClaims = namespacedClaims
-		self.flatClaims = flatClaims
+		self.claims = claims
 	}
 
 	public init?(from data: Data?) {

--- a/Sources/MdocDataModel18013/MdocResponse/IssuerSigned.swift
+++ b/Sources/MdocDataModel18013/MdocResponse/IssuerSigned.swift
@@ -22,12 +22,12 @@ import OrderedCollections
 public struct IssuerSigned: Sendable {
 	public let issuerNameSpaces: IssuerNameSpaces?
 	public let issuerAuth: IssuerAuth
-	
+
 	enum Keys: String {
 	   case nameSpaces
 	   case issuerAuth
 	 }
-	
+
 	public init(issuerNameSpaces: IssuerNameSpaces?, issuerAuth: IssuerAuth) {
 		self.issuerNameSpaces = issuerNameSpaces
 		self.issuerAuth = issuerAuth
@@ -53,14 +53,10 @@ extension IssuerSigned: CBOREncodable {
 
 extension IssuerSigned {
     public var validFrom: Date? {
-        let usDateStr = issuerAuth.mso.validityInfo.validFrom.usPosixDate()
-        let df = usDateFormatter
-        return df.date(from: usDateStr)
+        issuerAuth.mso.validityInfo.validFrom.convertToLocalDate()
     }
-    
+
     public var validUntil: Date? {
-        let usDateStr = issuerAuth.mso.validityInfo.validUntil.usPosixDate()
-        let df = usDateFormatter
-        return df.date(from: usDateStr)
+        issuerAuth.mso.validityInfo.validUntil.convertToLocalDate()
     }
 }

--- a/Sources/MdocDataModel18013/MdocResponse/IssuerSignedItem.swift
+++ b/Sources/MdocDataModel18013/MdocResponse/IssuerSignedItem.swift
@@ -44,7 +44,7 @@ extension CBOR: @retroactive CustomStringConvertible {
         switch self {
         case .utf8String(let str): return str
 		case .tagged(let tag, .utf8String(let str)):
-					if tag.rawValue == 1004 || tag == .standardDateTimeString { return str.usPosixDate() }
+					if tag.rawValue == 1004 || tag == .standardDateTimeString { return str }
 					return str
         case .unsignedInt(let i): return String(i)
         case .boolean(let b): return String(b)


### PR DESCRIPTION
Refactor the `DocMetadata` struct by removing unused properties and updating the initializer. Introduce a public initializer for `DocClaimMetadata`. Enhance date handling in `IssuerSigned` and `IssuerSignedItem` to utilize a new method for converting dates to local time.