### PR TITLE
Add StatusIdentifier for document status tracking

### DIFF
--- a/Sources/MdocDataModel18013/DocumentClaims/DocClaimsDecodable.swift
+++ b/Sources/MdocDataModel18013/DocumentClaims/DocClaimsDecodable.swift
@@ -49,6 +49,8 @@ public protocol DocClaimsDecodable: Sendable, AgeAttesting {
     var validFrom: Date? { get }
     /// Valid until date
     var validUntil: Date? { get }
+    /// This identifier is used to check the status of the document.
+    var statusIdentifier: StatusIdentifier? { get }
 } // end protocol
 
 /// Methods to extract CBOR values.

--- a/Sources/MdocDataModel18013/DocumentClaims/DocClaimsDecodable.swift
+++ b/Sources/MdocDataModel18013/DocumentClaims/DocClaimsDecodable.swift
@@ -150,9 +150,8 @@ extension DocClaimsDecodable {
 	/// - Parameters:
 	///   - nameSpaces: A dictionary where the key is a `NameSpace` and the value is an array of `IssuerSignedItem`.
 	///   - docClaims: An inout parameter that will be populated with `DocClaim` items extracted from the namespaces.
-	///   - claimDisplayNames: A dictionary where the key is the elementIdentifier and the value is a string representing the label.
-    ///   - mandatoryClaims: A dictionary where the key is the elementIdentifier and the value is a boolean indicating whether the claim is mandatory.
-    ///   - claimValueTypes: A dictionary where the key is the elementIdentifier and the value is a string representing the value type.
+	///   - displayNames: A namespaced dictionary where the key is the elementIdentifier and the value is a string representing the label.
+    ///   - mandatory: A namespaced dictionary where the key is the elementIdentifier and the value is a boolean indicating whether the claim is mandatory.
 	///   - nsFilter: An optional array of `NameSpace` to filter/sort the extraction. Defaults to `nil`.
 	public static func extractCborClaims(_ nameSpaces: [NameSpace: [IssuerSignedItem]], _ docClaims: inout [DocClaim], _ displayNames: [NameSpace: [String: String]]?, _ mandatory: [NameSpace: [String: Bool]]?, nsFilter: [NameSpace]? = nil) {
 		let bDebugDisplay = UserDefaults.standard.bool(forKey: "DebugDisplay")

--- a/Sources/MdocDataModel18013/DocumentClaims/DocClaimsDecodableFactory.swift
+++ b/Sources/MdocDataModel18013/DocumentClaims/DocClaimsDecodableFactory.swift
@@ -18,7 +18,7 @@ import Foundation
 
 /// A protocol to create a ``DocClaimsDecodable`` from a cbor encoded ``IssuerSigned`` struct
 public protocol DocClaimsDecodableFactory: Sendable {
-    func makeClaimsDecodableFromCbor(id: String, createdAt: Date, issuerSigned: IssuerSigned, displayName: String?, display: [DisplayMetadata]?, issuerDisplay: [DisplayMetadata]?, credentialIssuerIdentifier: String?, configurationIdentifier: String?, validFrom: Date?, validUntil: Date?, displayNames: [NameSpace: [String: String]]?, mandatory: [NameSpace: [String: Bool]]?) -> (
+    func makeClaimsDecodableFromCbor(id: String, createdAt: Date, issuerSigned: IssuerSigned, displayName: String?, display: [DisplayMetadata]?, issuerDisplay: [DisplayMetadata]?, credentialIssuerIdentifier: String?, configurationIdentifier: String?, validFrom: Date?, validUntil: Date?, statusIdentifier: StatusIdentifier?, displayNames: [NameSpace: [String: String]]?, mandatory: [NameSpace: [String: Bool]]?) -> (
         any DocClaimsDecodable
     )?
 }

--- a/Sources/MdocDataModel18013/IssuerAuth/StatusIdentifier.swift
+++ b/Sources/MdocDataModel18013/IssuerAuth/StatusIdentifier.swift
@@ -1,0 +1,38 @@
+/*
+Copyright (c) 2023 European Commission
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+import Foundation
+import SwiftCBOR
+
+/// A struct representing a status identifier, which includes an index and a URI string.
+public struct StatusIdentifier: Codable, Sendable {
+    public init(idx: Int, uriString: String) {
+        self.idx = idx
+        self.uriString = uriString
+    }
+    public let idx: Int
+    public let uriString: String
+}
+
+extension StatusIdentifier {
+    public init?(data msoRawData: [UInt8]) {
+		guard let obj = try? CBOR.decode(msoRawData) else { return nil }
+		guard case let CBOR.tagged(tag, cborEncoded) = obj, tag.rawValue == 24, case let .byteString(bytes) = cborEncoded else { return nil }
+		guard let cbor = try? CBOR.decode(bytes), case let .map(m) = cbor, case let .map(status) = m[.utf8String("status")] else { return nil }
+		if case let .map(status_list) = status[.utf8String("status_list")], case let .unsignedInt(idx) = status_list[.utf8String("idx")], case let .utf8String(uri) = status_list[.utf8String("uri")] {
+			self.idx = Int(idx); uriString = uri
+        } else { return nil }
+    }
+}

--- a/Sources/MdocDataModel18013/MdocKnownDocTypes/EuPidModel.swift
+++ b/Sources/MdocDataModel18013/MdocKnownDocTypes/EuPidModel.swift
@@ -33,6 +33,7 @@ public struct EuPidModel: Decodable, DocClaimsDecodable, Sendable {
     public var configurationIdentifier: String?
     public var validFrom: Date?
     public var validUntil: Date?
+    public var statusIdentifier: StatusIdentifier?
 	public let family_name: String?
 	public let given_name: String?
 	public let birth_date: String?
@@ -109,11 +110,11 @@ public struct EuPidModel: Decodable, DocClaimsDecodable, Sendable {
 }
 
 extension EuPidModel {
-	public init?(id: String, createdAt: Date, issuerSigned: IssuerSigned, displayName: String?, display: [DisplayMetadata]?, issuerDisplay: [DisplayMetadata]?, credentialIssuerIdentifier: String?, configurationIdentifier: String?, validFrom: Date?, validUntil: Date?, displayNames: [NameSpace: [String: String]]?, mandatory: [NameSpace: [String: Bool]]?) {
+	public init?(id: String, createdAt: Date, issuerSigned: IssuerSigned, displayName: String?, display: [DisplayMetadata]?, issuerDisplay: [DisplayMetadata]?, credentialIssuerIdentifier: String?, configurationIdentifier: String?, validFrom: Date?, validUntil: Date?, statusIdentifier: StatusIdentifier?, displayNames: [NameSpace: [String: String]]?, mandatory: [NameSpace: [String: Bool]]?) {
 		self.id = id
         self.createdAt = createdAt;	self.displayName = displayName; self.display = display; self.issuerDisplay = issuerDisplay
         self.credentialIssuerIdentifier = credentialIssuerIdentifier; self.configurationIdentifier = configurationIdentifier
-        self.validFrom = validFrom; self.validUntil = validUntil
+        self.validFrom = validFrom; self.validUntil = validUntil; self.statusIdentifier = statusIdentifier
 		guard let nameSpaces = Self.getCborSignedItems(issuerSigned) else { return nil }
 		Self.extractCborClaims(nameSpaces, &docClaims, displayNames, mandatory)
 		Self.extractAgeOverValues(nameSpaces, &ageOverXX)

--- a/Sources/MdocDataModel18013/MdocKnownDocTypes/GenericMdocModel.swift
+++ b/Sources/MdocDataModel18013/MdocKnownDocTypes/GenericMdocModel.swift
@@ -10,6 +10,7 @@ public struct GenericMdocModel: DocClaimsDecodable, Sendable {
     public var configurationIdentifier: String?
     public var validFrom: Date?
     public var validUntil: Date?
+    public var statusIdentifier: StatusIdentifier?
 	public var id: String = UUID().uuidString
 	public var createdAt: Date = Date()
 	public var docType: String?
@@ -20,7 +21,7 @@ public struct GenericMdocModel: DocClaimsDecodable, Sendable {
     public var docDataFormat: DocDataFormat
     public var hashingAlg: String?
 
-    public init(id: String = UUID().uuidString, createdAt: Date = Date(), docType: String?, displayName: String?, display: [DisplayMetadata]?, issuerDisplay: [DisplayMetadata]? = nil, credentialIssuerIdentifier: String?, configurationIdentifier: String?, validFrom: Date?, validUntil: Date?, modifiedAt: Date?, ageOverXX: [Int : Bool] = [Int: Bool](), docClaims: [DocClaim] = [DocClaim](), docDataFormat: DocDataFormat, hashingAlg: String?) {
+    public init(id: String = UUID().uuidString, createdAt: Date = Date(), docType: String?, displayName: String?, display: [DisplayMetadata]?, issuerDisplay: [DisplayMetadata]? = nil, credentialIssuerIdentifier: String?, configurationIdentifier: String?, validFrom: Date?, validUntil: Date?, statusIdentifier: StatusIdentifier?, modifiedAt: Date?, ageOverXX: [Int : Bool] = [Int: Bool](), docClaims: [DocClaim] = [DocClaim](), docDataFormat: DocDataFormat, hashingAlg: String?) {
         self.id = id
         self.createdAt = createdAt
         self.docType = docType
@@ -30,6 +31,7 @@ public struct GenericMdocModel: DocClaimsDecodable, Sendable {
         self.configurationIdentifier = configurationIdentifier
         self.validFrom = validFrom
         self.validUntil = validUntil
+        self.statusIdentifier = statusIdentifier
         self.modifiedAt = modifiedAt
         self.ageOverXX = ageOverXX
         self.docClaims = docClaims
@@ -39,11 +41,11 @@ public struct GenericMdocModel: DocClaimsDecodable, Sendable {
 
 extension GenericMdocModel {
 
-	public init?(id: String, createdAt: Date, issuerSigned: IssuerSigned, docType: String, displayName: String?, display: [DisplayMetadata]?, issuerDisplay: [DisplayMetadata]?, credentialIssuerIdentifier: String?, configurationIdentifier: String?, validFrom: Date?, validUntil: Date?, displayNames: [NameSpace: [String: String]]?, mandatory: [NameSpace: [String: Bool]]?) {
+	public init?(id: String, createdAt: Date, issuerSigned: IssuerSigned, docType: String, displayName: String?, display: [DisplayMetadata]?, issuerDisplay: [DisplayMetadata]?, credentialIssuerIdentifier: String?, configurationIdentifier: String?, validFrom: Date?, validUntil: Date?, statusIdentifier: StatusIdentifier?, displayNames: [NameSpace: [String: String]]?, mandatory: [NameSpace: [String: Bool]]?) {
         self.id = id; self.createdAt = createdAt; self.displayName = displayName
         self.display = display; self.issuerDisplay = issuerDisplay
         self.credentialIssuerIdentifier = credentialIssuerIdentifier; self.configurationIdentifier = configurationIdentifier
-        self.validFrom = validFrom; self.validUntil = validUntil
+        self.validFrom = validFrom; self.validUntil = validUntil; self.statusIdentifier = statusIdentifier
         self.docType = docType; self.docDataFormat = .cbor
 		if let nameSpaces = Self.getCborSignedItems(issuerSigned) {
 			Self.extractCborClaims(nameSpaces, &docClaims, displayNames, mandatory)

--- a/Sources/MdocDataModel18013/MdocKnownDocTypes/IsoMdlModel.swift
+++ b/Sources/MdocDataModel18013/MdocKnownDocTypes/IsoMdlModel.swift
@@ -25,6 +25,7 @@ public struct IsoMdlModel: Decodable, DocClaimsDecodable, Sendable {
     public var configurationIdentifier: String?
     public var validFrom: Date?
     public var validUntil: Date?
+    public var statusIdentifier: StatusIdentifier?
 	public var id: String = UUID().uuidString
 	public var createdAt: Date = Date()
 	public var docType: String? = Self.isoDocType
@@ -127,10 +128,10 @@ public struct IsoMdlModel: Decodable, DocClaimsDecodable, Sendable {
 
 
 extension IsoMdlModel {
-	public init?(id: String, createdAt: Date, issuerSigned: IssuerSigned, displayName: String?, display: [DisplayMetadata]?, issuerDisplay: [DisplayMetadata]?, credentialIssuerIdentifier: String?, configurationIdentifier: String?, validFrom: Date?, validUntil: Date?, displayNames: [NameSpace: [String: String]]?, mandatory: [NameSpace: [String: Bool]]?) {
+	public init?(id: String, createdAt: Date, issuerSigned: IssuerSigned, displayName: String?, display: [DisplayMetadata]?, issuerDisplay: [DisplayMetadata]?, credentialIssuerIdentifier: String?, configurationIdentifier: String?, validFrom: Date?, validUntil: Date?, statusIdentifier: StatusIdentifier?, displayNames: [NameSpace: [String: String]]?, mandatory: [NameSpace: [String: Bool]]?) {
         self.id = id; self.createdAt = createdAt; self.displayName = displayName; self.display = display; self.issuerDisplay = issuerDisplay
         self.credentialIssuerIdentifier = credentialIssuerIdentifier; self.configurationIdentifier = configurationIdentifier
-        self.validFrom = validFrom; self.validUntil = validUntil
+        self.validFrom = validFrom; self.validUntil = validUntil; self.statusIdentifier = statusIdentifier
   	    guard let nameSpaceItems = Self.getCborSignedItems(issuerSigned, nameSpaces) else { return nil }
 		Self.extractCborClaims(nameSpaceItems, &docClaims, displayNames, mandatory)
 		func getValue<T>(key: IsoMdlModel.CodingKeys) -> T? { Self.getCborItemValue(nameSpaceItems, string: key.rawValue) }

--- a/Tests/MdocDataModel18013Tests/MdocDataModel18013Tests.swift
+++ b/Tests/MdocDataModel18013Tests/MdocDataModel18013Tests.swift
@@ -95,9 +95,9 @@ final class MdocDataModel18013Tests: XCTestCase {
 	  	let d1 = try XCTUnwrap(docs.first(where: {$0.docType == EuPidModel.euPidDocType}))
 		let d2 = try XCTUnwrap(docs.first(where: {$0.docType == IsoMdlModel.isoDocType}))
 		//let ns1 = d1?.issuerSigned.issuerNameSpaces!.nameSpaces.first
-		let pidObj = try XCTUnwrap(EuPidModel(id: UUID().uuidString, createdAt: Date(), issuerSigned: d1.issuerSigned, displayName: "PID", display: nil, issuerDisplay: nil, credentialIssuerIdentifier: nil, configurationIdentifier: nil, validFrom: d1.issuerSigned.validFrom, validUntil: d1.issuerSigned.validUntil, displayNames: nil, mandatory: nil))
+		let pidObj = try XCTUnwrap(EuPidModel(id: UUID().uuidString, createdAt: Date(), issuerSigned: d1.issuerSigned, displayName: "PID", display: nil, issuerDisplay: nil, credentialIssuerIdentifier: nil, configurationIdentifier: nil, validFrom: d1.issuerSigned.validFrom, validUntil: d1.issuerSigned.validUntil, statusIdentifier: d1.issuerSigned.issuerAuth.statusIdentifier, displayNames: nil, mandatory: nil))
 		XCTAssertEqual(pidObj.family_name, "ANDERSSON")
-		let mdlObj = try XCTUnwrap(IsoMdlModel(id: UUID().uuidString, createdAt: Date(), issuerSigned: d2.issuerSigned, displayName: "mDL", display: nil, issuerDisplay: nil, credentialIssuerIdentifier: nil, configurationIdentifier: nil, validFrom: d1.issuerSigned.validFrom, validUntil: d1.issuerSigned.validUntil, displayNames: nil, mandatory: nil))
+		let mdlObj = try XCTUnwrap(IsoMdlModel(id: UUID().uuidString, createdAt: Date(), issuerSigned: d2.issuerSigned, displayName: "mDL", display: nil, issuerDisplay: nil, credentialIssuerIdentifier: nil, configurationIdentifier: nil, validFrom: d1.issuerSigned.validFrom, validUntil: d1.issuerSigned.validUntil, statusIdentifier: d1.issuerSigned.issuerAuth.statusIdentifier, displayNames: nil, mandatory: nil))
 		XCTAssertEqual(mdlObj.familyName, "ANDERSSON")
 		printDisplayStrings(mdlObj.docClaims)
 	}
@@ -139,7 +139,7 @@ final class MdocDataModel18013Tests: XCTestCase {
 		XCTAssertEqual(doc.deviceSigned?.deviceAuth.coseMacOrSignature.macAlgorithm, Cose.MacAlgorithm.hmac256)
 		XCTAssertEqual(doc.deviceSigned?.deviceAuth.coseMacOrSignature.signature.bytes.toHexString().uppercased(), "E99521A85AD7891B806A07F8B5388A332D92C189A7BF293EE1F543405AE6824D")
         let d1 = dr.documents!.first!
-		let model = try XCTUnwrap(IsoMdlModel(id: UUID().uuidString, createdAt: Date(), issuerSigned: d1.issuerSigned, displayName: "PID", display: nil, issuerDisplay: nil, credentialIssuerIdentifier: nil, configurationIdentifier: nil, validFrom: d1.issuerSigned.validFrom, validUntil: d1.issuerSigned.validUntil, displayNames: nil, mandatory: nil))
+		let model = try XCTUnwrap(IsoMdlModel(id: UUID().uuidString, createdAt: Date(), issuerSigned: d1.issuerSigned, displayName: "PID", display: nil, issuerDisplay: nil, credentialIssuerIdentifier: nil, configurationIdentifier: nil, validFrom: d1.issuerSigned.validFrom, validUntil: d1.issuerSigned.validUntil, statusIdentifier: d1.issuerSigned.issuerAuth.statusIdentifier, displayNames: nil, mandatory: nil))
 		XCTAssertEqual(model.familyName, "Doe")
 	}
 


### PR DESCRIPTION
Introduce a new `StatusIdentifier` struct to represent document status with an index and URI. Update relevant models and initializers to include this new property, enhancing the clarity and functionality of the status representation.