### PR TITLE
Add CredentialsUsageCounts for usage tracking, validUntil nil when count is zero

### DIFF
--- a/Sources/MdocDataModel18013/DocumentClaims/DocClaimsDecodable.swift
+++ b/Sources/MdocDataModel18013/DocumentClaims/DocClaimsDecodable.swift
@@ -53,6 +53,8 @@ public protocol DocClaimsDecodable: Sendable, AgeAttesting {
     var statusIdentifier: StatusIdentifier? { get }
     /// Secure area name for the saved credentials
     var secureAreaName: String? { get }
+    /// Remaining credentials to be used for presentation. If nil, the credentials do not expire.
+    var credentialsUsageCounts: CredentialsUsageCounts? { get set }
 } // end protocol
 
 /// Methods to extract CBOR values.

--- a/Sources/MdocDataModel18013/MdocKnownDocTypes/EuPidModel.swift
+++ b/Sources/MdocDataModel18013/MdocKnownDocTypes/EuPidModel.swift
@@ -32,9 +32,11 @@ public struct EuPidModel: Decodable, DocClaimsDecodable, Sendable {
     public var credentialIssuerIdentifier: String?
     public var configurationIdentifier: String?
     public var validFrom: Date?
-    public var validUntil: Date?
+    private var _validUntil: Date?
+    public var validUntil: Date? { if let uc = credentialsUsageCounts, uc.remaining <= 0 { return nil } else { return _validUntil } }
     public var statusIdentifier: StatusIdentifier?
-    public var secureAreaName: String? 
+    public var credentialsUsageCounts: CredentialsUsageCounts?
+    public var secureAreaName: String?
 	public let family_name: String?
 	public let given_name: String?
 	public let birth_date: String?
@@ -115,7 +117,7 @@ extension EuPidModel {
 		self.id = id
         self.createdAt = createdAt;	self.displayName = displayName; self.display = display; self.issuerDisplay = issuerDisplay
         self.credentialIssuerIdentifier = credentialIssuerIdentifier; self.configurationIdentifier = configurationIdentifier
-        self.validFrom = validFrom; self.validUntil = validUntil; self.statusIdentifier = statusIdentifier; self.secureAreaName = secureAreaName
+        self.validFrom = validFrom; self._validUntil = validUntil; self.statusIdentifier = statusIdentifier; self.secureAreaName = secureAreaName
 		guard let nameSpaces = Self.getCborSignedItems(issuerSigned) else { return nil }
 		Self.extractCborClaims(nameSpaces, &docClaims, displayNames, mandatory)
 		Self.extractAgeOverValues(nameSpaces, &ageOverXX)

--- a/Sources/MdocDataModel18013/MdocKnownDocTypes/GenericMdocModel.swift
+++ b/Sources/MdocDataModel18013/MdocKnownDocTypes/GenericMdocModel.swift
@@ -9,9 +9,11 @@ public struct GenericMdocModel: DocClaimsDecodable, Sendable {
     public var credentialIssuerIdentifier: String?
     public var configurationIdentifier: String?
     public var validFrom: Date?
-    public var validUntil: Date?
+    private var _validUntil: Date?
+    public var validUntil: Date? { if let uc = credentialsUsageCounts, uc.remaining <= 0 { return nil } else { return _validUntil } }
     public var statusIdentifier: StatusIdentifier?
-    public var secureAreaName: String? 
+    public var credentialsUsageCounts: CredentialsUsageCounts?
+    public var secureAreaName: String?
 	public var id: String = UUID().uuidString
 	public var createdAt: Date = Date()
 	public var docType: String?
@@ -31,7 +33,7 @@ public struct GenericMdocModel: DocClaimsDecodable, Sendable {
         self.credentialIssuerIdentifier = credentialIssuerIdentifier
         self.configurationIdentifier = configurationIdentifier
         self.validFrom = validFrom
-        self.validUntil = validUntil
+        self._validUntil = validUntil
         self.statusIdentifier = statusIdentifier
         self.secureAreaName = secureAreaName
         self.modifiedAt = modifiedAt
@@ -47,7 +49,7 @@ extension GenericMdocModel {
         self.id = id; self.createdAt = createdAt; self.displayName = displayName
         self.display = display; self.issuerDisplay = issuerDisplay
         self.credentialIssuerIdentifier = credentialIssuerIdentifier; self.configurationIdentifier = configurationIdentifier
-        self.validFrom = validFrom; self.validUntil = validUntil; self.statusIdentifier = statusIdentifier; self.secureAreaName = secureAreaName
+        self.validFrom = validFrom; self._validUntil = validUntil; self.statusIdentifier = statusIdentifier; self.secureAreaName = secureAreaName
         self.docType = docType; self.docDataFormat = .cbor
 		if let nameSpaces = Self.getCborSignedItems(issuerSigned) {
 			Self.extractCborClaims(nameSpaces, &docClaims, displayNames, mandatory)

--- a/Sources/MdocDataModel18013/MdocKnownDocTypes/IsoMdlModel.swift
+++ b/Sources/MdocDataModel18013/MdocKnownDocTypes/IsoMdlModel.swift
@@ -24,9 +24,11 @@ public struct IsoMdlModel: Decodable, DocClaimsDecodable, Sendable {
     public var credentialIssuerIdentifier: String?
     public var configurationIdentifier: String?
     public var validFrom: Date?
-    public var validUntil: Date?
+    private var _validUntil: Date?
+    public var validUntil: Date? { if let uc = credentialsUsageCounts, uc.remaining <= 0 { return nil } else { return _validUntil } }
     public var statusIdentifier: StatusIdentifier?
-    public var secureAreaName: String? 
+    public var credentialsUsageCounts: CredentialsUsageCounts?
+    public var secureAreaName: String?
 	public var id: String = UUID().uuidString
 	public var createdAt: Date = Date()
 	public var docType: String? = Self.isoDocType
@@ -132,7 +134,7 @@ extension IsoMdlModel {
 	public init?(id: String, createdAt: Date, issuerSigned: IssuerSigned, displayName: String?, display: [DisplayMetadata]?, issuerDisplay: [DisplayMetadata]?, credentialIssuerIdentifier: String?, configurationIdentifier: String?, validFrom: Date?, validUntil: Date?, statusIdentifier: StatusIdentifier?, secureAreaName: String?, displayNames: [NameSpace: [String: String]]?, mandatory: [NameSpace: [String: Bool]]?) {
         self.id = id; self.createdAt = createdAt; self.displayName = displayName; self.display = display; self.issuerDisplay = issuerDisplay
         self.credentialIssuerIdentifier = credentialIssuerIdentifier; self.configurationIdentifier = configurationIdentifier
-        self.validFrom = validFrom; self.validUntil = validUntil; self.statusIdentifier = statusIdentifier; self.secureAreaName = secureAreaName
+        self.validFrom = validFrom; self._validUntil = validUntil; self.statusIdentifier = statusIdentifier; self.secureAreaName = secureAreaName
   	    guard let nameSpaceItems = Self.getCborSignedItems(issuerSigned, nameSpaces) else { return nil }
 		Self.extractCborClaims(nameSpaceItems, &docClaims, displayNames, mandatory)
 		func getValue<T>(key: IsoMdlModel.CodingKeys) -> T? { Self.getCborItemValue(nameSpaceItems, string: key.rawValue) }

--- a/Sources/MdocDataModel18013/SecureArea/CredentialsUsageCounts.swift
+++ b/Sources/MdocDataModel18013/SecureArea/CredentialsUsageCounts.swift
@@ -1,0 +1,29 @@
+/*
+Copyright (c) 2023 European Commission
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+		http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import Foundation
+
+public struct CredentialsUsageCounts: Codable, Sendable {
+    public let total: Int
+    public let remaining: Int
+    public var used: Int  { total - remaining }
+
+    public init(total: Int, remaining: Int) throws {
+        self.total = total
+        self.remaining = remaining
+		if total < remaining { fatalError("Total count cannot be less than remaining count") }
+    }
+}


### PR DESCRIPTION
Introduce a new `CredentialsUsageCounts` struct to track credential usage. Update the `DocClaimsDecodable` protocol and its implementations to include usage tracking, modifying the behavior of the `validUntil` property based on remaining credentials.