### PR TITLE
Make publicKey optional in CoseKeyExchange (not needed for deviceSignature)

### DIFF
--- a/Sources/MdocDataModel18013/DeviceEngagement/CoseKey.swift
+++ b/Sources/MdocDataModel18013/DeviceEngagement/CoseKey.swift
@@ -119,10 +119,10 @@ extension CoseKey {
 
 /// A COSE_Key exchange pair
 public struct CoseKeyExchange: Sendable {
-	public let publicKey: CoseKey
+	public let publicKey: CoseKey?
 	public var privateKey: CoseKeyPrivate
 
-	public init(publicKey: CoseKey, privateKey: CoseKeyPrivate) {
+	public init(publicKey: CoseKey?, privateKey: CoseKeyPrivate) {
 		self.publicKey = publicKey
 		self.privateKey = privateKey
 	}


### PR DESCRIPTION
Change the `publicKey` property in `CoseKeyExchange` to be optional, enhancing flexibility in key management.