### PR TITLE
Improve CBOR decoding error messages for IssuerNameSpaces and IssuerSigned

### DIFF
--- a/Sources/MdocDataModel18013/MdocResponse/IssuerNameSpaces.swift
+++ b/Sources/MdocDataModel18013/MdocResponse/IssuerNameSpaces.swift
@@ -31,12 +31,14 @@ public struct IssuerNameSpaces: Sendable {
 
 extension IssuerNameSpaces: CBORDecodable {
 	public init(cbor: CBOR) throws(MdocValidationError) {
-		guard case let .map(m) = cbor else { throw .invalidCbor("issuer signed") }
+		guard case let .map(m) = cbor else { throw .invalidCbor("issuer namespaces") }
 		var temp = [NameSpace: [IssuerSignedItem]]()
 		for (k,v) in m {
 			guard case let .utf8String(ns) = k, case let .array(ar) = v else { continue }
 			let items = try ar.map { c throws(MdocValidationError) -> IssuerSignedItem in
-				guard case let .tagged(tg, cbs) = c, tg == .encodedCBORDataItem, case let .byteString(bs) = cbs else { throw .invalidCbor("issuer signed") }
+				guard case let .tagged(tg, cbs) = c, tg == .encodedCBORDataItem, case let .byteString(bs) = cbs else {
+                    throw .invalidCbor("issuer signed item '\(k)'")
+                }
 				return try IssuerSignedItem(data: bs)
 			}
 			temp[ns] = items

--- a/Sources/MdocDataModel18013/MdocResponse/IssuerSigned.swift
+++ b/Sources/MdocDataModel18013/MdocResponse/IssuerSigned.swift
@@ -36,7 +36,7 @@ public struct IssuerSigned: Sendable {
 
 extension IssuerSigned: CBORDecodable {
 	public init(cbor: CBOR) throws(MdocValidationError) {
-		guard case let .map(m) = cbor else { throw .invalidCbor("issuer signed") }
+		guard case let .map(m) = cbor else { throw .invalidCbor("issuer signed must be a map") }
 		if let cn = m[Keys.nameSpaces] { issuerNameSpaces = try IssuerNameSpaces(cbor: cn) } else { issuerNameSpaces = nil }
 		guard let cia = m[Keys.issuerAuth] else { throw .missingField("IssuerSigned", Keys.issuerAuth.rawValue) }
         issuerAuth = try IssuerAuth(cbor: cia)


### PR DESCRIPTION
Enhance error messages during CBOR decoding to provide clearer context for issues related to IssuerNameSpaces and IssuerSigned. This change improves debugging and error handling.