### PR TITLE
Downgrade Swift tools version to 6.0

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 6.2
+// swift-tools-version: 6.0
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription


### PR DESCRIPTION
Change the Swift tools version in `Package.swift` from 6.2 to 6.0 to ensure compatibility with older Swift versions.