### PR TITLE
Make DocClaimsModel class open for subclassing

### DIFF
--- a/Sources/MdocDataModel18013/DocumentClaims/DocMetadata.swift
+++ b/Sources/MdocDataModel18013/DocumentClaims/DocMetadata.swift
@@ -39,8 +39,10 @@ public struct DocMetadata: Sendable, Codable {
     public let keyOptions: KeyOptions?
     // credential options used to create the document
     public let credentialOptions: CredentialOptions?
+	/// the DPoP key identifier used for proof of possession
+	public let dpopKeyId: String?
 
-	public init(credentialIssuerIdentifier: String, configurationIdentifier: String, docType: String, display: [DisplayMetadata]?, issuerDisplay: [DisplayMetadata]?, claims: [DocClaimMetadata]?, authorizedRequestData: Data?, keyOptions: KeyOptions?, credentialOptions: CredentialOptions?) {
+	public init(credentialIssuerIdentifier: String, configurationIdentifier: String, docType: String, display: [DisplayMetadata]?, issuerDisplay: [DisplayMetadata]?, claims: [DocClaimMetadata]?, authorizedRequestData: Data?, keyOptions: KeyOptions?, credentialOptions: CredentialOptions?, dpopKeyId: String? = nil) {
 		self.authorizedRequestData = authorizedRequestData
 		self.credentialIssuerIdentifier = credentialIssuerIdentifier
 		self.configurationIdentifier = configurationIdentifier
@@ -50,6 +52,7 @@ public struct DocMetadata: Sendable, Codable {
 		self.claims = claims
 		self.keyOptions = keyOptions
 		self.credentialOptions = credentialOptions
+		self.dpopKeyId = dpopKeyId
 	}
 
 	public init?(from data: Data?) {

--- a/Sources/MdocDataModel18013/MdocKnownDocTypes/DocClaimsModel.swift
+++ b/Sources/MdocDataModel18013/MdocKnownDocTypes/DocClaimsModel.swift
@@ -6,7 +6,7 @@ import Foundation
 /// SAFETY INVARIANT (@unchecked Sendable):
 /// This class is marked @unchecked Sendable because it contains a mutable property (credentialsUsageCounts)
 /// that may be updated after initialization. Updates to this property must be performed by external code that ensures proper synchronization.
-public class DocClaimsModel: DocClaimsDecodable, @unchecked Sendable, ObservableObject, Equatable {
+open class DocClaimsModel: DocClaimsDecodable, @unchecked Sendable, ObservableObject, Equatable {
     public let display: [DisplayMetadata]?
     public let issuerDisplay: [DisplayMetadata]?
     public let credentialIssuerIdentifier: String?


### PR DESCRIPTION
Change the visibility of the DocClaimsModel class from `public` to `open` to enable subclassing outside the module while preserving existing conformances and safety invariants.