### PR TITLE
readerAuthAll is array of readerAuth COSE_SIGN1

### DIFF
--- a/Sources/MdocDataModel18013/MdocRequest/DeviceRequest.swift
+++ b/Sources/MdocDataModel18013/MdocRequest/DeviceRequest.swift
@@ -40,8 +40,8 @@ public struct DeviceRequest: Sendable {
     /// Optional device request info (tag 24 encoded)
     public let deviceRequestInfo: DeviceRequestInfo?
     // optional reader auth all
-    public let readerAuthAll: ReaderAuth?
-    public let readerAuthAllRawCBOR: CBOR?
+    public let readerAuthAll: [ReaderAuth]?
+    public let readerAuthAllRawCBOR: [CBOR]?
 
     enum Keys: String {
         case version
@@ -66,7 +66,11 @@ extension DeviceRequest: CBORDecodable {
                   let decoded = try? CBOR.decode(bytes) else { throw .invalidCbor("DeviceRequest") }
             deviceRequestInfo = try DeviceRequestInfo(cbor: decoded)
         } else { deviceRequestInfo = nil }
-        if let ra = m[Keys.readerAuthAll] { readerAuthAllRawCBOR = ra; readerAuthAll = try ReaderAuth(cbor: ra) } else { readerAuthAllRawCBOR = nil; readerAuthAll = nil }
+        if case let .array(ra) = m[Keys.readerAuthAll] {
+            readerAuthAllRawCBOR = ra
+            do { readerAuthAll = try ra.map { try ReaderAuth(cbor: $0) } } catch { throw .invalidCbor("readerAuthAll") }
+        }
+        else { readerAuthAllRawCBOR = nil; readerAuthAll = nil }
     }
 }
 


### PR DESCRIPTION
Change readerAuthAll and its raw CBOR to arrays ([ReaderAuth]? and [CBOR]?) and update CBOR decoding to handle a CBOR.array case. The decoder now assigns the raw CBOR array and maps each element to a ReaderAuth, throwing an invalidCbor error if any element fails to decode. Falls back to nil when the key is absent.