### PR TITLE
Fix: updated DisplayMetaData to take backgroundImageURL 

### DIFF
--- a/Sources/MdocDataModel18013/DocumentClaims/DisplayMetadata.swift
+++ b/Sources/MdocDataModel18013/DocumentClaims/DisplayMetadata.swift
@@ -22,15 +22,17 @@ public struct DisplayMetadata: Codable, Equatable, Sendable {
     public let logo: LogoMetadata?
     public let description: String?
     public let backgroundColor: String?
+    public let backgroundImageURL: String?
     public let textColor: String?
     public var locale: Locale? { Locale(identifier: localeIdentifier ?? "en_US") }
     
-    public init(name: String? = nil, localeIdentifier: String? = nil, logo: LogoMetadata? = nil, description: String? = nil, backgroundColor: String? = nil, textColor: String? = nil) {
+    public init(name: String? = nil, localeIdentifier: String? = nil, logo: LogoMetadata? = nil, description: String? = nil, backgroundColor: String? = nil, textColor: String? = nil, backgroundImageURL: String? = nil) {
         self.name = name
         self.localeIdentifier = localeIdentifier
         self.logo = logo
         self.description = description
         self.backgroundColor = backgroundColor
         self.textColor = textColor
+        self.backgroundImageURL = backgroundImageURL
     }
 }


### PR DESCRIPTION
This PR introduces adds the property, backgroundImageURL, to the DisplayMetadata struct.
This is needed for the background image from the issuerMetaData of the credential.

Link to the issue: PR (https://github.com/eu-digital-identity-wallet/eudi-lib-ios-iso18013-data-model/issues/106)