### PR TITLE
backgroundImageURL metadata property added,  transaction log struct added

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "9694a8d19e6b91c85a65e6772e2b97cf60359ed5bece090ff8c1ad8908485d95",
+  "originHash" : "9ea02768ee851616c3f0de28ea0e503056b01b74e58342f3667521800ba0a36e",
   "pins" : [
     {
       "identity" : "swift-collections",
@@ -15,8 +15,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-log.git",
       "state" : {
-        "revision" : "7ee16e465622412764b0ff0c1301801dc71b8f61",
-        "version" : "1.9.0"
+        "revision" : "bbd81b6725ae874c69e9b8c8804d462356b55523",
+        "version" : "1.10.1"
       }
     },
     {

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "9ea02768ee851616c3f0de28ea0e503056b01b74e58342f3667521800ba0a36e",
+  "originHash" : "34a85f35ad8be12e1a1212dc2407b49b87749a8e69ecbbdade838fe310db0247",
   "pins" : [
     {
       "identity" : "swift-collections",
@@ -20,12 +20,30 @@
       }
     },
     {
+      "identity" : "swift-syntax",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/swiftlang/swift-syntax.git",
+      "state" : {
+        "revision" : "64889f0c732f210a935a0ad7cda38f77f876262d",
+        "version" : "509.1.1"
+      }
+    },
+    {
       "identity" : "swiftcbor",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/niscy-eudiw/SwiftCBOR.git",
       "state" : {
         "revision" : "a663e7a6bd50d2224223ed60622b531b18499dd0",
         "version" : "0.6.4"
+      }
+    },
+    {
+      "identity" : "swiftcopyablemacro",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/eu-digital-identity-wallet/SwiftCopyableMacro.git",
+      "state" : {
+        "revision" : "d535b0836be52c846d87605adad1205445e4dc35",
+        "version" : "0.0.4"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -16,7 +16,7 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/niscy-eudiw/SwiftCBOR.git", from: "0.6.4"),
         .package(url: "https://github.com/SwiftyJSON/SwiftyJSON.git", from: "5.0.1"),
-        .package(url: "https://github.com/apple/swift-log.git", from: "1.9.0"),
+        .package(url: "https://github.com/apple/swift-log.git", from: "1.10.1"),
     ]
     ,
 

--- a/Package.swift
+++ b/Package.swift
@@ -17,6 +17,7 @@ let package = Package(
         .package(url: "https://github.com/niscy-eudiw/SwiftCBOR.git", from: "0.6.4"),
         .package(url: "https://github.com/SwiftyJSON/SwiftyJSON.git", from: "5.0.1"),
         .package(url: "https://github.com/apple/swift-log.git", from: "1.10.1"),
+		.package(url: "https://github.com/eu-digital-identity-wallet/SwiftCopyableMacro.git", from: "0.0.3")
     ]
     ,
 
@@ -28,7 +29,8 @@ let package = Package(
             dependencies: [
                 "SwiftCBOR",
                 .product(name: "SwiftyJSON", package: "SwiftyJSON"),
-                .product(name: "Logging", package: "swift-log")
+                .product(name: "Logging", package: "swift-log"),
+				.product(name: "Copyable", package: "SwiftCopyableMacro"),
                 ]
             ),
         .testTarget(

--- a/Sources/MdocDataModel18013/DocumentClaims/DisplayMetadata.swift
+++ b/Sources/MdocDataModel18013/DocumentClaims/DisplayMetadata.swift
@@ -24,13 +24,15 @@ public struct DisplayMetadata: Codable, Equatable, Sendable {
     public let backgroundColor: String?
     public let textColor: String?
     public var locale: Locale? { Locale(identifier: localeIdentifier ?? "en_US") }
+    public let backgroundImageURL: String?
     
-    public init(name: String? = nil, localeIdentifier: String? = nil, logo: LogoMetadata? = nil, description: String? = nil, backgroundColor: String? = nil, textColor: String? = nil) {
+    public init(name: String? = nil, localeIdentifier: String? = nil, logo: LogoMetadata? = nil, description: String? = nil, backgroundColor: String? = nil, textColor: String? = nil, backgroundImageURL: String? = nil) {
         self.name = name
         self.localeIdentifier = localeIdentifier
         self.logo = logo
         self.description = description
         self.backgroundColor = backgroundColor
         self.textColor = textColor
+        self.backgroundImageURL = backgroundImageURL
     }
 }

--- a/Sources/MdocDataModel18013/DocumentClaims/TransactionLog.swift
+++ b/Sources/MdocDataModel18013/DocumentClaims/TransactionLog.swift
@@ -1,3 +1,19 @@
+/*
+Copyright (c) 2023 European Commission
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 import Foundation
 import Copyable
 /// Transaction log.

--- a/Sources/MdocDataModel18013/DocumentClaims/TransactionLog.swift
+++ b/Sources/MdocDataModel18013/DocumentClaims/TransactionLog.swift
@@ -1,0 +1,83 @@
+import Foundation
+import Copyable
+/// Transaction log.
+@Copyable
+public struct TransactionLog: Sendable, Codable {
+	public init(timestamp: Int64, status: Status, errorMessage: String? = nil, rawRequest: Data? = nil, rawResponse: Data? = nil, relyingParty: RelyingParty? = nil, issuingParty: IssuingParty? = nil, type: TransactionLog.LogType, dataFormat: TransactionLog.DataFormat, sessionTranscript: Data? = nil, docMetadata: [Data?]? = nil, documentId: String? = nil, docType: String? = nil, displayName: String? = nil) {
+		// Initialize the properties with the provided values
+		self.timestamp = timestamp
+		self.status = status
+		self.errorMessage = errorMessage
+		self.rawRequest = rawRequest
+		self.rawResponse = rawResponse
+		self.relyingParty = relyingParty
+		self.issuingParty = issuingParty
+		self.type = type
+		self.dataFormat = dataFormat
+		self.sessionTranscript = sessionTranscript
+		self.docMetadata = docMetadata
+		self.documentId = documentId
+		self.docType = docType
+		self.displayName = displayName
+	}
+
+	public let timestamp: Int64
+	public let status: Status
+	public let errorMessage: String?
+	public let rawRequest: Data?
+	public let rawResponse: Data?
+	public let relyingParty: RelyingParty?
+	public let issuingParty: IssuingParty?
+	public let type: LogType
+	public let dataFormat: DataFormat
+	public let sessionTranscript: Data?
+	public let docMetadata: [Data?]?
+	public let documentId: String?
+	public let docType: String?
+	public let displayName: String?
+
+	public enum DataFormat: Int, Sendable, Codable {
+		case cbor
+		case json
+
+		public init(_ format: DocDataFormat) {
+			switch format {
+			case .cbor: self = .cbor
+			case .sdjwt: self = .json
+			}
+		}
+	}
+
+	public struct RelyingParty: Codable, Sendable {
+		/// The name of the relying party
+		public let name: String
+		/// Whether the relying party is verified.
+		public let isVerified: Bool
+		/// The certificate chain of the relying party.
+		public let certificateChain: [Data]
+		/// The reader authentication data. This is populated only when mdoc presentation is used.
+		public let readerAuth: Data?
+	}
+
+	public struct IssuingParty: Codable, Sendable {
+		public let name: String
+		public let identifier: String
+		public let logoUrl: String?
+	}
+
+	public enum LogType: Int, Sendable, Codable {
+		case presentation
+		case issuance
+		case signing
+		case deletion
+	}
+
+	public enum Status: Int, Sendable, Codable {
+		/// Indicates that the transaction is incomplete
+		case incomplete
+		// Indicates that the transaction was completed successfully.
+		case completed
+		// Indicates that the transaction failed.
+		case failed
+	}
+}

--- a/Sources/MdocDataModel18013/DocumentClaims/TransactionLogger.swift
+++ b/Sources/MdocDataModel18013/DocumentClaims/TransactionLogger.swift
@@ -1,0 +1,26 @@
+/*
+Copyright (c) 2023 European Commission
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import Foundation
+
+/// A logger for transactions.
+///
+/// Implementations of this protocol should log transactions to some persistent storage.
+/// The storage can be a file, a database, or any other storage medium.
+public protocol TransactionLogger: Actor {
+    ///  Logs a transaction.
+    func log(transaction: TransactionLog) async throws
+}


### PR DESCRIPTION
Upgrade the `swift-log` dependency to version 1.10.1 and introduce the `backgroundImageURL` property in the `DisplayMetadata` struct. Additionally, add a new `TransactionLog` struct to enhance transaction logging capabilities.