### PR TITLE
Fix multiple issues including date-time validation, field renaming, and mandatory elements

### DIFF
--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -1,5 +1,5 @@
 EU Digital Identity Wallet
-Copyright (c) 2023 European Commission
+Copyright (c) 2026 European Commission
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 
 (1) google/identity-credential (available at https://github.com/google/identity-credential)
-Certain file packages were originally created under the Apache License, Version 2.0.  These files have been copied into this project and modified.  All modifications are Copyright 2023 European Commission, and are licensed under the Apache License, Version 2.0.
+Certain file packages were originally created under the Apache License, Version 2.0.  These files have been copied into this project and modified.  All modifications are Copyright 2026 European Commission, and are licensed under the Apache License, Version 2.0.
 
 Original License:
                                  Apache License

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ The released software is a initial development release version:
 
 ### License details
 
-Copyright (c) 2023 European Commission
+Copyright (c) 2026 European Commission
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/Sources/MdocDataModel18013/Cose.swift
+++ b/Sources/MdocDataModel18013/Cose.swift
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2023 European Commission
+Copyright (c) 2026 European Commission
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/Sources/MdocDataModel18013/DE+QRCode.swift
+++ b/Sources/MdocDataModel18013/DE+QRCode.swift
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2023 European Commission
+Copyright (c) 2026 European Commission
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/Sources/MdocDataModel18013/Data+Base64URL.swift
+++ b/Sources/MdocDataModel18013/Data+Base64URL.swift
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2023 European Commission
+Copyright (c) 2026 European Commission
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/Sources/MdocDataModel18013/Data+Base64URL.swift
+++ b/Sources/MdocDataModel18013/Data+Base64URL.swift
@@ -18,12 +18,6 @@ import Foundation
 
 extension Data {
 
-/// init from local file
-    public init?(name: String, ext: String = "json", from bundle:Bundle = Bundle.main) {
-        guard let url = bundle.url(forResource: name, withExtension: ext) else { return nil }
-        try? self.init(contentsOf: url, options: .mappedIfSafe)
-    }
-
 		public func decodeJSON<T: Decodable>(type: T.Type = T.self) -> T? {
         let decoder = JSONDecoder()
         guard let response = try? decoder.decode(type.self, from: self) else { return nil }

--- a/Sources/MdocDataModel18013/DeviceEngagement/CoseKey.swift
+++ b/Sources/MdocDataModel18013/DeviceEngagement/CoseKey.swift
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2023 European Commission
+Copyright (c) 2026 European Commission
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/Sources/MdocDataModel18013/DeviceEngagement/CoseKey.swift
+++ b/Sources/MdocDataModel18013/DeviceEngagement/CoseKey.swift
@@ -48,12 +48,12 @@ public struct CoseKeyPrivate: Sendable {
     public var index: Int!
     public var secureArea: (any SecureArea)!
 
-    public init(privateKeyId: String, index: Int, secureArea: any SecureArea, curve: CoseEcCurve = .P256) async throws {
+	/// Initialize with existing key in secure area
+    public init(privateKeyId: String, index: Int, secureArea: any SecureArea, curve: CoseEcCurve) async throws {
         logger.info("Loading cose key private with id: \(privateKeyId)")
 		self.privateKeyId = privateKeyId
         self.index = index
 		self.secureArea = secureArea
-		try await makeKey(curve: curve)
 		self.key = try await secureArea.getPublicKey(id: privateKeyId, index: index, curve: curve)
 	}
 

--- a/Sources/MdocDataModel18013/DeviceEngagement/CoseKey.swift
+++ b/Sources/MdocDataModel18013/DeviceEngagement/CoseKey.swift
@@ -48,11 +48,13 @@ public struct CoseKeyPrivate: Sendable {
     public var index: Int!
     public var secureArea: (any SecureArea)!
 
-    public init(privateKeyId: String, index: Int, secureArea: any SecureArea) {
+    public init(privateKeyId: String, index: Int, secureArea: any SecureArea, curve: CoseEcCurve = .P256) async throws {
         logger.info("Loading cose key private with id: \(privateKeyId)")
 		self.privateKeyId = privateKeyId
         self.index = index
 		self.secureArea = secureArea
+		try await makeKey(curve: curve)
+		self.key = try await secureArea.getPublicKey(id: privateKeyId, index: index, curve: curve)
 	}
 
     public init(secureArea: any SecureArea) {
@@ -67,7 +69,15 @@ extension CoseKeyPrivate {
         let ephemeralKeyId = UUID().uuidString
         index = 0
         privateKeyId = ephemeralKeyId
-        self.key = (try await secureArea.createKeyBatch(id: ephemeralKeyId, credentialOptions: CredentialOptions(credentialPolicy: .rotateUse, batchSize: 1), keyOptions: KeyOptions(curve: curve))).first!
+        let createdKeys = try await secureArea.createKeyBatch(
+            id: ephemeralKeyId,
+            credentialOptions: CredentialOptions(credentialPolicy: .rotateUse, batchSize: 1),
+            keyOptions: KeyOptions(curve: curve)
+        )
+        guard let firstKey = createdKeys.first else {
+            throw SecureAreaError("Secure area returned an empty key batch")
+        }
+        self.key = firstKey
 	}
 }
 

--- a/Sources/MdocDataModel18013/DeviceEngagement/DeviceEngagement.swift
+++ b/Sources/MdocDataModel18013/DeviceEngagement/DeviceEngagement.swift
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2023 European Commission
+Copyright (c) 2026 European Commission
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/Sources/MdocDataModel18013/DeviceEngagement/DeviceEngagement.swift
+++ b/Sources/MdocDataModel18013/DeviceEngagement/DeviceEngagement.swift
@@ -41,6 +41,7 @@ import Crypto
 /// ```
 public struct DeviceEngagement: Sendable {
 	static let versionImpl: String = "1.0"
+	static let version2 = "1.1"
 	var version: String = Self.versionImpl
 	var security: Security!
 	public var originInfos: [OriginInfoWebsite]? = nil
@@ -105,7 +106,8 @@ extension DeviceEngagement: CBOREncodable {
 extension DeviceEngagement: CBORDecodable {
 	public init(cbor: CBOR) throws(MdocValidationError) {
 		guard case let .map(map) = cbor else { throw .invalidCbor("device engagement") }
-		guard let cv = map[0], case let .utf8String(v) = cv, v.prefix(2) == "1." else { throw .invalidCbor("device engagement") }
+		guard let cv = map[0], case let .utf8String(v) = cv else { throw .invalidCbor("device engagement") }
+		try MdocVersion.validateDeviceVersion(v, component: "device engagement")
 		guard let cs = map[1] else { throw .invalidCbor("device engagement") }
         security = try Security(cbor: cs)
 		if let cdrms = map[2], case let .array(drms) = cdrms, drms.count > 0 { deviceRetrievalMethods = try drms.map(DeviceRetrievalMethod.init(cbor:)) }

--- a/Sources/MdocDataModel18013/DeviceEngagement/DeviceEngagement.swift
+++ b/Sources/MdocDataModel18013/DeviceEngagement/DeviceEngagement.swift
@@ -68,10 +68,10 @@ public struct DeviceEngagement: Sendable {
 	}
 
     public mutating func makePrivateKey(crv: CoseEcCurve, secureArea: any SecureArea) async throws {
-        var pk = CoseKeyPrivate(secureArea: secureArea)
-        try await pk.makeKey(curve: crv)
-        privateKey = pk
-        security = Security(deviceKey: pk.key)
+		var generatedPrivateKey = CoseKeyPrivate(secureArea: secureArea)
+		try await generatedPrivateKey.makeKey(curve: crv)
+		privateKey = generatedPrivateKey
+		security = Security(deviceKey: generatedPrivateKey.key)
     }
 
 	public var isBleServer: Bool? {

--- a/Sources/MdocDataModel18013/DeviceEngagement/DeviceEngagement.swift
+++ b/Sources/MdocDataModel18013/DeviceEngagement/DeviceEngagement.swift
@@ -54,11 +54,16 @@ public struct DeviceEngagement: Sendable {
 
 	/// Generate device engagement
 	/// - Parameters
-	///    - isBleServer: true for BLE mdoc peripheral server mode, false for BLE mdoc central client mode
+	///    - supportsCentralClientMode: true if the holder supports BLE central client mode
+	///    - supportsPeripheralServerMode: true if the holder supports BLE peripheral server mode
 	///    - crv: The EC curve type used in the mdoc ephemeral private key
-    public init?(isBleServer: Bool?, rfus: [String]? = nil) {
+    public init?(supportsCentralClientMode: Bool, supportsPeripheralServerMode: Bool, rfus: [String]? = nil) {
 		self.rfus = rfus
-        if let isBleServer { deviceRetrievalMethods = [.ble(isBleServer: isBleServer, uuid: UUID())] }
+		let uuid = UUID()
+		guard supportsCentralClientMode || supportsPeripheralServerMode else { return nil }
+		deviceRetrievalMethods = []
+		if supportsCentralClientMode { deviceRetrievalMethods!.append(.ble(peripheralServerMode: false, uuid: uuid)) }
+        if supportsPeripheralServerMode { deviceRetrievalMethods!.append(.ble(peripheralServerMode: true, uuid: uuid)) }
 	}
 	/// initialize from cbor data
 	public init(data: [UInt8]) throws {
@@ -73,17 +78,25 @@ public struct DeviceEngagement: Sendable {
         security = Security(deviceKey: pk.key)
     }
 
-	public var isBleServer: Bool? {
-		guard let deviceRetrievalMethods else { return nil}
-		for case let .ble(isBleServer, _) in deviceRetrievalMethods {
-			return isBleServer
+	public var supportsCentralClientMode: Bool {
+		guard let deviceRetrievalMethods else { return false }
+		for case let .ble(peripheralServerMode, _, _) in deviceRetrievalMethods {
+			return !peripheralServerMode
 		}
-		return nil
+		return false
+	}
+
+	public var supportsPeripheralServerMode: Bool {
+		guard let deviceRetrievalMethods else { return false }
+		for case let .ble(peripheralServerMode, _, _) in deviceRetrievalMethods {
+			return peripheralServerMode
+		}
+		return false
 	}
 
 	public var ble_uuid: String? {
 		guard let deviceRetrievalMethods else { return nil}
-		for case let .ble(_, uuid) in deviceRetrievalMethods {
+		for case let .ble(_, uuid, _) in deviceRetrievalMethods {
             return uuid.uuidString
 		}
 		return nil

--- a/Sources/MdocDataModel18013/DeviceEngagement/DeviceRetrievalMethod.swift
+++ b/Sources/MdocDataModel18013/DeviceEngagement/DeviceRetrievalMethod.swift
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2023 European Commission
+Copyright (c) 2026 European Commission
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/Sources/MdocDataModel18013/DeviceEngagement/DeviceRetrievalMethod.swift
+++ b/Sources/MdocDataModel18013/DeviceEngagement/DeviceRetrievalMethod.swift
@@ -25,7 +25,6 @@ import SwiftCBOR
 public enum DeviceRetrievalMethod: Equatable, Sendable {
     static var version: UInt64 { 1 }
 
-    case qr
     case nfc(maxLenCommand: UInt64, maxLenResponse: UInt64)
     case ble(isBleServer: Bool, uuid: UUID)
     //  case wifiaware // not supported in ios
@@ -38,8 +37,6 @@ extension DeviceRetrievalMethod: CBOREncodable {
 	public func toCBOR(options: CBOROptions) -> CBOR {
         var cborArr = [CBOR]()
         switch self {
-        case .qr:
-            Self.appendTypeAndVersion(&cborArr, type: 0)
         case .nfc(let maxLenCommand, let maxLenResponse):
             Self.appendTypeAndVersion(&cborArr, type: 1)
             let options: CBOR = [0: .unsignedInt(maxLenCommand), 1: .unsignedInt(maxLenResponse)]
@@ -59,8 +56,6 @@ extension DeviceRetrievalMethod: CBORDecodable {
         guard case let .unsignedInt(type) = arr[0] else { throw .invalidCbor("device retrieval method") }
         guard case let .unsignedInt(v) = arr[1], v == Self.version else { throw .invalidCbor("device retrieval method") }
         switch type {
-        case 0:
-            self = .qr
         case 1:
             guard case let .map(options) = arr[2] else { throw .invalidCbor("device retrieval method") }
             guard case let .unsignedInt(mlc) = options[0], case let .unsignedInt(mlr) = options[1]  else { throw .invalidCbor("device retrieval method") }

--- a/Sources/MdocDataModel18013/DeviceEngagement/DeviceRetrievalMethod.swift
+++ b/Sources/MdocDataModel18013/DeviceEngagement/DeviceRetrievalMethod.swift
@@ -27,7 +27,7 @@ public enum DeviceRetrievalMethod: Equatable, Sendable {
 
     case qr
     case nfc(maxLenCommand: UInt64, maxLenResponse: UInt64)
-    case ble(isBleServer: Bool, uuid: UUID)
+    case ble(peripheralServerMode: Bool, uuid: UUID, psm: UInt16? = nil) // psm is optional for future use, not used in current version
     //  case wifiaware // not supported in ios
 }
 
@@ -44,9 +44,10 @@ extension DeviceRetrievalMethod: CBOREncodable {
             Self.appendTypeAndVersion(&cborArr, type: 1)
             let options: CBOR = [0: .unsignedInt(maxLenCommand), 1: .unsignedInt(maxLenResponse)]
             cborArr.append(options)
-        case .ble(let isBleServer, let uuid):
+        case .ble(let peripheralServerMode, let uuid, let psm):
             Self.appendTypeAndVersion(&cborArr, type: 2)
-            let options: CBOR = [0: .boolean(isBleServer), 1: .boolean(!isBleServer), .unsignedInt(isBleServer ? 10 : 11): .byteString(uuid.uuidString.replacingOccurrences(of: "-", with: "").byteArray)]
+            var options: CBOR = [0: .boolean(peripheralServerMode), 1: .boolean(!peripheralServerMode), .unsignedInt(peripheralServerMode ? 10 : 11): .byteString(uuid.uuidString.replacingOccurrences(of: "-", with: "").byteArray)]
+            if let psm { options[21] = .unsignedInt(UInt64(psm)) }
             cborArr.append(options)
         }
         return .array(cborArr)
@@ -68,9 +69,11 @@ extension DeviceRetrievalMethod: CBORDecodable {
         case 2:
             guard case let .map(options) = arr[2] else { throw .invalidCbor("device retrieval method") }
             if case let .boolean(b) = options[0], b, case let .byteString(bytes) = options[10], let uuid = UUID(uuidBytes: bytes) {
-                self = .ble(isBleServer: b, uuid: uuid)
+                let psm: UInt16? = if case let .unsignedInt(p) = options[21] { UInt16(p) } else { nil }
+                self = .ble(peripheralServerMode: b, uuid: uuid, psm: psm)
             } else if case let .boolean(b) = options[1], b, case let .byteString(bytes) = options[11], let uuid = UUID(uuidBytes: bytes) {
-                self = .ble(isBleServer: !b, uuid: uuid)
+                let psm: UInt16? = if case let .unsignedInt(p) = options[21] { UInt16(p) } else { nil }
+                self = .ble(peripheralServerMode: !b, uuid: uuid, psm: psm)
             } else { throw .invalidCbor("device retrieval method") }
         default: throw .invalidCbor("device retrieval method")
         }

--- a/Sources/MdocDataModel18013/DeviceEngagement/OriginInfoWebsite.swift
+++ b/Sources/MdocDataModel18013/DeviceEngagement/OriginInfoWebsite.swift
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2023 European Commission
+Copyright (c) 2026 European Commission
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/Sources/MdocDataModel18013/DeviceEngagement/Security.swift
+++ b/Sources/MdocDataModel18013/DeviceEngagement/Security.swift
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2023 European Commission
+Copyright (c) 2026 European Commission
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/Sources/MdocDataModel18013/DeviceEngagement/ServerRetrievalOption.swift
+++ b/Sources/MdocDataModel18013/DeviceEngagement/ServerRetrievalOption.swift
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2023 European Commission
+Copyright (c) 2026 European Commission
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/Sources/MdocDataModel18013/DeviceEngagement/ServerRetrievalOptions.swift
+++ b/Sources/MdocDataModel18013/DeviceEngagement/ServerRetrievalOptions.swift
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2023 European Commission
+Copyright (c) 2026 European Commission
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/Sources/MdocDataModel18013/DocumentClaims/DisplayMetadata.swift
+++ b/Sources/MdocDataModel18013/DocumentClaims/DisplayMetadata.swift
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2023 European Commission
+Copyright (c) 2026 European Commission
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/Sources/MdocDataModel18013/DocumentClaims/DocClaim.swift
+++ b/Sources/MdocDataModel18013/DocumentClaims/DocClaim.swift
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2023 European Commission
+Copyright (c) 2026 European Commission
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/Sources/MdocDataModel18013/DocumentClaims/DocClaimMetadata.swift
+++ b/Sources/MdocDataModel18013/DocumentClaims/DocClaimMetadata.swift
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2023 European Commission
+Copyright (c) 2026 European Commission
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/Sources/MdocDataModel18013/DocumentClaims/DocClaimsDecodable.swift
+++ b/Sources/MdocDataModel18013/DocumentClaims/DocClaimsDecodable.swift
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2023 European Commission
+Copyright (c) 2026 European Commission
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/Sources/MdocDataModel18013/DocumentClaims/DocClaimsDecodable.swift
+++ b/Sources/MdocDataModel18013/DocumentClaims/DocClaimsDecodable.swift
@@ -91,9 +91,9 @@ extension DocClaimsDecodable {
 	public static func extractAgeOverValues(_ nameSpaces: [NameSpace: [IssuerSignedItem]], _ ageOverXX: inout [Int: Bool]) {
 		for (_, items) in nameSpaces {
 			for item in items {
-				let k = item.elementIdentifier
-				if !k.hasPrefix("age_over_") { continue }
-				if let age = Int(k.suffix(k.count - 9)) {
+				let elementIdentifier = item.elementIdentifier
+				if !elementIdentifier.hasPrefix("age_over_") { continue }
+				if let age = Int(elementIdentifier.suffix(elementIdentifier.count - 9)) {
 					let b: Bool? = item.getTypedValue()
 					if let b { ageOverXX[age] = b }
 				}

--- a/Sources/MdocDataModel18013/DocumentClaims/DocClaimsDecodableFactory.swift
+++ b/Sources/MdocDataModel18013/DocumentClaims/DocClaimsDecodableFactory.swift
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2023 European Commission
+Copyright (c) 2026 European Commission
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/Sources/MdocDataModel18013/DocumentClaims/DocDataFormat.swift
+++ b/Sources/MdocDataModel18013/DocumentClaims/DocDataFormat.swift
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2023 European Commission
+Copyright (c) 2026 European Commission
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/Sources/MdocDataModel18013/DocumentClaims/DocMetadata.swift
+++ b/Sources/MdocDataModel18013/DocumentClaims/DocMetadata.swift
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2023 European Commission
+Copyright (c) 2026 European Commission
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/Sources/MdocDataModel18013/DocumentClaims/LogoMetadata.swift
+++ b/Sources/MdocDataModel18013/DocumentClaims/LogoMetadata.swift
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2023 European Commission
+Copyright (c) 2026 European Commission
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/Sources/MdocDataModel18013/DocumentClaims/TransactionLog.swift
+++ b/Sources/MdocDataModel18013/DocumentClaims/TransactionLog.swift
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2023 European Commission
+Copyright (c) 2026 European Commission
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/Sources/MdocDataModel18013/DocumentClaims/TransactionLogger.swift
+++ b/Sources/MdocDataModel18013/DocumentClaims/TransactionLogger.swift
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2023 European Commission
+Copyright (c) 2026 European Commission
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/Sources/MdocDataModel18013/DrivingPrivileges/DrivingPrivilege.swift
+++ b/Sources/MdocDataModel18013/DrivingPrivileges/DrivingPrivilege.swift
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2023 European Commission
+Copyright (c) 2026 European Commission
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/Sources/MdocDataModel18013/DrivingPrivileges/DrivingPrivilegeCode.swift
+++ b/Sources/MdocDataModel18013/DrivingPrivileges/DrivingPrivilegeCode.swift
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2023 European Commission
+Copyright (c) 2026 European Commission
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/Sources/MdocDataModel18013/DrivingPrivileges/DrivingPrivileges.swift
+++ b/Sources/MdocDataModel18013/DrivingPrivileges/DrivingPrivileges.swift
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2023 European Commission
+Copyright (c) 2026 European Commission
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/Sources/MdocDataModel18013/Extensions.swift
+++ b/Sources/MdocDataModel18013/Extensions.swift
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2023 European Commission
+Copyright (c) 2026 European Commission
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/Sources/MdocDataModel18013/IssuerAuth/DeviceKeyInfo.swift
+++ b/Sources/MdocDataModel18013/IssuerAuth/DeviceKeyInfo.swift
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2023 European Commission
+Copyright (c) 2026 European Commission
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/Sources/MdocDataModel18013/IssuerAuth/DeviceKeyInfo.swift
+++ b/Sources/MdocDataModel18013/IssuerAuth/DeviceKeyInfo.swift
@@ -43,21 +43,21 @@ public struct DeviceKeyInfo:Sendable {
 
 extension DeviceKeyInfo: CBORDecodable {
 	public init(cbor: CBOR) throws(MdocValidationError) {
-		guard case let .map(v) = cbor else { throw MdocValidationError.invalidCbor("device key info") }
-		guard let cdk = v[Keys.deviceKey] else { throw MdocValidationError.missingField("DeviceKeyInfo", "deviceKey") }
-		deviceKey = try CoseKey(cbor: cdk)
-		if let cka = v[Keys.keyAuthorizations] { keyAuthorizations = try KeyAuthorizations(cbor: cka) } else { keyAuthorizations = nil }
-		keyInfo = v[Keys.keyInfo]
+		guard case let .map(cborMap) = cbor else { throw MdocValidationError.invalidCbor("device key info") }
+		guard let cborDeviceKey = cborMap[Keys.deviceKey] else { throw MdocValidationError.missingField("DeviceKeyInfo", "deviceKey") }
+		deviceKey = try CoseKey(cbor: cborDeviceKey)
+		if let cborKeyAuthorizations = cborMap[Keys.keyAuthorizations] { keyAuthorizations = try KeyAuthorizations(cbor: cborKeyAuthorizations) } else { keyAuthorizations = nil }
+		keyInfo = cborMap[Keys.keyInfo]
 	}
 }
 
 extension DeviceKeyInfo: CBOREncodable {
 	public func toCBOR(options: CBOROptions) -> CBOR {
-		var m = OrderedDictionary<CBOR, CBOR>()
-		m[.utf8String(Keys.deviceKey.rawValue)] = deviceKey.toCBOR(options: options)
-		if let keyAuthorizations { m[.utf8String(Keys.keyAuthorizations.rawValue)] = keyAuthorizations.toCBOR(options: options) }
-		if let keyInfo { m[.utf8String(Keys.keyInfo.rawValue)] = keyInfo }
-		return .map(m)
+		var map = OrderedDictionary<CBOR, CBOR>()
+		map[.utf8String(Keys.deviceKey.rawValue)] = deviceKey.toCBOR(options: options)
+		if let keyAuthorizations { map[.utf8String(Keys.keyAuthorizations.rawValue)] = keyAuthorizations.toCBOR(options: options) }
+		if let keyInfo { map[.utf8String(Keys.keyInfo.rawValue)] = keyInfo }
+		return .map(map)
 	}
 }
 
@@ -74,37 +74,37 @@ struct KeyAuthorizations: Sendable {
 
 extension KeyAuthorizations: CBORDecodable {
 	init(cbor: CBOR) throws(MdocValidationError) {
-		guard case let .map(v) = cbor else { throw MdocValidationError.invalidCbor("key authorizations") }
-		var ans: AuthorizedNameSpaces? = nil
-		if case let .array(ar) = v[Keys.nameSpaces] {
-			ans = ar.compactMap { if case let .utf8String(s) = $0 { return s} else { return nil} }
-			if ans?.count == 0 { ans = nil }
+		guard case let .map(cborMap) = cbor else { throw MdocValidationError.invalidCbor("key authorizations") }
+		var authorizedNameSpaces: AuthorizedNameSpaces? = nil
+		if case let .array(nameSpaceValues) = cborMap[Keys.nameSpaces] {
+			authorizedNameSpaces = nameSpaceValues.compactMap { if case let .utf8String(value) = $0 { return value } else { return nil } }
+			if authorizedNameSpaces?.count == 0 { authorizedNameSpaces = nil }
 		}
-		nameSpaces = ans
-		var de = [NameSpace: DataElementsArray]()
-		if case let .map(mde) = v[Keys.dataElements] {
-			for (k,v) in mde  {
-				guard case let .utf8String(ns) = k, case let .array(cdea) = v else { continue }
-				let dea = cdea.compactMap { if case let .utf8String(s) = $0 { return s} else { return nil} }
-				guard dea.count > 0 else { continue }
-				de[ns] = dea
+		nameSpaces = authorizedNameSpaces
+		var authorizedDataElements = [NameSpace: DataElementsArray]()
+		if case let .map(dataElementsMap) = cborMap[Keys.dataElements] {
+			for (nameSpaceKey, nameSpaceValue) in dataElementsMap  {
+				guard case let .utf8String(nameSpace) = nameSpaceKey, case let .array(dataElementValues) = nameSpaceValue else { continue }
+				let dataElementIdentifiers = dataElementValues.compactMap { if case let .utf8String(value) = $0 { return value } else { return nil } }
+				guard dataElementIdentifiers.count > 0 else { continue }
+				authorizedDataElements[nameSpace] = dataElementIdentifiers
 			}
 		}
-		if de.count > 0 { dataElements = de } else { dataElements = nil }
+		if authorizedDataElements.count > 0 { dataElements = authorizedDataElements } else { dataElements = nil }
 	}
 }
 
 extension KeyAuthorizations: CBOREncodable {
 	public func toCBOR(options: CBOROptions) -> CBOR {
-		var m = OrderedDictionary<CBOR, CBOR>()
+		var map = OrderedDictionary<CBOR, CBOR>()
 		if let nameSpaces {
-			m[.utf8String(Keys.nameSpaces.rawValue)] = .array(nameSpaces.map { .utf8String($0) })
+			map[.utf8String(Keys.nameSpaces.rawValue)] = .array(nameSpaces.map { .utf8String($0) })
 		}
 		if let dataElements {
-			var d = OrderedDictionary<CBOR, CBOR>()
-			for (k,v) in dataElements { d[.utf8String(k)] = .array(v.map { .utf8String($0) }) }
-			m[.utf8String(Keys.dataElements.rawValue)] = .map(d)
+			var dataElementsCborMap = OrderedDictionary<CBOR, CBOR>()
+			for (nameSpace, dataElementIdentifiers) in dataElements { dataElementsCborMap[.utf8String(nameSpace)] = .array(dataElementIdentifiers.map { .utf8String($0) }) }
+			map[.utf8String(Keys.dataElements.rawValue)] = .map(dataElementsCborMap)
 		}
-		return .map(m)
+		return .map(map)
 	}
 }

--- a/Sources/MdocDataModel18013/IssuerAuth/DigestIDs.swift
+++ b/Sources/MdocDataModel18013/IssuerAuth/DigestIDs.swift
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2023 European Commission
+Copyright (c) 2026 European Commission
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/Sources/MdocDataModel18013/IssuerAuth/DigestIDs.swift
+++ b/Sources/MdocDataModel18013/IssuerAuth/DigestIDs.swift
@@ -44,10 +44,10 @@ extension DigestIDs: CBORDecodable {
 
 extension DigestIDs: CBOREncodable {
 	public func toCBOR(options: CBOROptions) -> CBOR {
-		var m = OrderedDictionary<CBOR, CBOR>()
+		var map = OrderedDictionary<CBOR, CBOR>()
 		for (k,v) in digestIDs {
-			m[.unsignedInt(k)] = .byteString(v)
+			map[.unsignedInt(k)] = .byteString(v)
 		}
-		return .map(m)
+		return .map(map)
 	}
 }

--- a/Sources/MdocDataModel18013/IssuerAuth/IssuerAuth.swift
+++ b/Sources/MdocDataModel18013/IssuerAuth/IssuerAuth.swift
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2023 European Commission
+Copyright (c) 2026 European Commission
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/Sources/MdocDataModel18013/IssuerAuth/MobileSecurityObject.swift
+++ b/Sources/MdocDataModel18013/IssuerAuth/MobileSecurityObject.swift
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2023 European Commission
+Copyright (c) 2026 European Commission
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/Sources/MdocDataModel18013/IssuerAuth/MobileSecurityObject.swift
+++ b/Sources/MdocDataModel18013/IssuerAuth/MobileSecurityObject.swift
@@ -84,13 +84,13 @@ extension MobileSecurityObject: CBORDecodable {
 
 extension MobileSecurityObject: CBOREncodable {
 	public func toCBOR(options: CBOROptions) -> CBOR {
-		var m = OrderedDictionary<CBOR, CBOR>()
-		m[.utf8String(Keys.version.rawValue)] = .utf8String(version)
-		m[.utf8String(Keys.digestAlgorithm.rawValue)] = .utf8String(digestAlgorithm)
-		m[.utf8String(Keys.valueDigests.rawValue)] = valueDigests.toCBOR(options: options)
-		m[.utf8String(Keys.deviceKeyInfo.rawValue)] = deviceKeyInfo.toCBOR(options: options)
-		m[.utf8String(Keys.docType.rawValue)] = .utf8String(docType)
-		m[.utf8String(Keys.validityInfo.rawValue)] = validityInfo.toCBOR(options: options)
-		return .map(m)
+		var map = OrderedDictionary<CBOR, CBOR>()
+		map[.utf8String(Keys.version.rawValue)] = .utf8String(version)
+		map[.utf8String(Keys.digestAlgorithm.rawValue)] = .utf8String(digestAlgorithm)
+		map[.utf8String(Keys.valueDigests.rawValue)] = valueDigests.toCBOR(options: options)
+		map[.utf8String(Keys.deviceKeyInfo.rawValue)] = deviceKeyInfo.toCBOR(options: options)
+		map[.utf8String(Keys.docType.rawValue)] = .utf8String(docType)
+		map[.utf8String(Keys.validityInfo.rawValue)] = validityInfo.toCBOR(options: options)
+		return .map(map)
 	}
 }

--- a/Sources/MdocDataModel18013/IssuerAuth/StatusIdentifier.swift
+++ b/Sources/MdocDataModel18013/IssuerAuth/StatusIdentifier.swift
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2023 European Commission
+Copyright (c) 2026 European Commission
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/Sources/MdocDataModel18013/IssuerAuth/ValidityInfo.swift
+++ b/Sources/MdocDataModel18013/IssuerAuth/ValidityInfo.swift
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2023 European Commission
+Copyright (c) 2026 European Commission
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/Sources/MdocDataModel18013/IssuerAuth/ValidityInfo.swift
+++ b/Sources/MdocDataModel18013/IssuerAuth/ValidityInfo.swift
@@ -45,12 +45,18 @@ extension ValidityInfo: CBORDecodable {
 	public init(cbor: CBOR) throws(MdocValidationError) {
 		guard case let .map(v) = cbor else { throw .invalidCbor("validity info") }
 		guard case .tagged(let t, let cs) = v[Keys.signed], t == .standardDateTimeString, case let .utf8String(s) = cs else { throw .missingField("ValidityInfo", Keys.signed.rawValue) }
+		guard !s.contains(".") else { throw .invalidDateTimeFormat("ValidityInfo", Keys.signed.rawValue) }
 		signed = s
 		guard case .tagged(let t, let cvf) = v[Keys.validFrom], t == .standardDateTimeString, case let .utf8String(vf) = cvf else { throw .missingField("ValidityInfo", Keys.validFrom.rawValue) }
+		guard !vf.contains(".") else { throw .invalidDateTimeFormat("ValidityInfo", Keys.validFrom.rawValue) }
 		validFrom = vf
 		guard case .tagged(let t, let cvu) = v[Keys.validUntil], t == .standardDateTimeString, case let .utf8String(vu) = cvu else { throw .missingField("ValidityInfo", Keys.validUntil.rawValue) }
+		guard !vu.contains(".") else { throw .invalidDateTimeFormat("ValidityInfo", Keys.validUntil.rawValue) }
 		validUntil = vu
-		if case .tagged(let t, let ceu) = v[Keys.expectedUpdate], t == .standardDateTimeString, case let .utf8String(eu) = ceu { expectedUpdate = eu } else { expectedUpdate = nil }
+		if case .tagged(let t, let ceu) = v[Keys.expectedUpdate], t == .standardDateTimeString, case let .utf8String(eu) = ceu {
+			guard !eu.contains(".") else { throw .invalidDateTimeFormat("ValidityInfo", Keys.expectedUpdate.rawValue) }
+			expectedUpdate = eu
+		} else { expectedUpdate = nil }
 	}
 }
 

--- a/Sources/MdocDataModel18013/IssuerAuth/ValidityInfo.swift
+++ b/Sources/MdocDataModel18013/IssuerAuth/ValidityInfo.swift
@@ -62,12 +62,12 @@ extension ValidityInfo: CBORDecodable {
 
 extension ValidityInfo: CBOREncodable {
 	public func toCBOR(options: CBOROptions) -> CBOR {
-		var m = OrderedDictionary<CBOR, CBOR>()
-		m[.utf8String(Keys.signed.rawValue)] = .tagged(.standardDateTimeString, .utf8String(signed))
-		m[.utf8String(Keys.validFrom.rawValue)] = .tagged(.standardDateTimeString, .utf8String(validFrom))
-		m[.utf8String(Keys.validUntil.rawValue)] = .tagged(.standardDateTimeString, .utf8String(validUntil))
-		if let expectedUpdate { m[.utf8String(Keys.expectedUpdate.rawValue)] = .tagged(.standardDateTimeString, .utf8String(expectedUpdate)) }
-		return .map(m)
+		var map = OrderedDictionary<CBOR, CBOR>()
+		map[.utf8String(Keys.signed.rawValue)] = .tagged(.standardDateTimeString, .utf8String(signed))
+		map[.utf8String(Keys.validFrom.rawValue)] = .tagged(.standardDateTimeString, .utf8String(validFrom))
+		map[.utf8String(Keys.validUntil.rawValue)] = .tagged(.standardDateTimeString, .utf8String(validUntil))
+		if let expectedUpdate { map[.utf8String(Keys.expectedUpdate.rawValue)] = .tagged(.standardDateTimeString, .utf8String(expectedUpdate)) }
+		return .map(map)
 	}
 }
 

--- a/Sources/MdocDataModel18013/IssuerAuth/ValueDigests.swift
+++ b/Sources/MdocDataModel18013/IssuerAuth/ValueDigests.swift
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2023 European Commission
+Copyright (c) 2026 European Commission
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/Sources/MdocDataModel18013/IssuerAuth/ValueDigests.swift
+++ b/Sources/MdocDataModel18013/IssuerAuth/ValueDigests.swift
@@ -43,11 +43,11 @@ extension ValueDigests: CBORDecodable {
 
 extension ValueDigests: CBOREncodable {
 	public func toCBOR(options: CBOROptions) -> CBOR {
-		var m = OrderedDictionary<CBOR, CBOR>()
+		var map = OrderedDictionary<CBOR, CBOR>()
 		for (k,v) in valueDigests {
-			m[.utf8String(k)] = v.toCBOR(options: CBOROptions())
+			map[.utf8String(k)] = v.toCBOR(options: CBOROptions())
 		}
-		return .map(m)
+		return .map(map)
 	}
 }
 

--- a/Sources/MdocDataModel18013/MdocDataModel18013.swift
+++ b/Sources/MdocDataModel18013/MdocDataModel18013.swift
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2023 European Commission
+Copyright (c) 2026 European Commission
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/Sources/MdocDataModel18013/MdocKnownDocTypes/AgeAttesting.swift
+++ b/Sources/MdocDataModel18013/MdocKnownDocTypes/AgeAttesting.swift
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2023 European Commission
+Copyright (c) 2026 European Commission
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/Sources/MdocDataModel18013/MdocKnownDocTypes/EuPidModel.swift
+++ b/Sources/MdocDataModel18013/MdocKnownDocTypes/EuPidModel.swift
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2023 European Commission
+Copyright (c) 2026 European Commission
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/Sources/MdocDataModel18013/MdocKnownDocTypes/EuPidModel.swift
+++ b/Sources/MdocDataModel18013/MdocKnownDocTypes/EuPidModel.swift
@@ -90,7 +90,7 @@ public final class EuPidModel: DocClaimsModel, @unchecked Sendable {
         case trust_anchor
 	}
 	static var mandatoryElementCodingKeys: [CodingKeys] {
-		[.family_name, .given_name, .birth_date]
+		[.family_name, .given_name, .birth_date, .birth_place, .nationality]
 	}
     public static var pidMandatoryElementKeys: [DataElementIdentifier] { ["age_over_18"] + mandatoryElementCodingKeys.map(\.rawValue) }
 	public var mandatoryElementKeys: [DataElementIdentifier] { Self.pidMandatoryElementKeys }

--- a/Sources/MdocDataModel18013/MdocKnownDocTypes/IsoMdlModel.swift
+++ b/Sources/MdocDataModel18013/MdocKnownDocTypes/IsoMdlModel.swift
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2023 European Commission
+Copyright (c) 2026 European Commission
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/Sources/MdocDataModel18013/MdocRequest/DeviceRequest.swift
+++ b/Sources/MdocDataModel18013/MdocRequest/DeviceRequest.swift
@@ -67,6 +67,7 @@ extension DeviceRequest: CBORDecodable {
             deviceRequestInfo = try DeviceRequestInfo(cbor: decoded)
         } else { deviceRequestInfo = nil }
         if case let .array(ra) = m[Keys.readerAuthAll] {
+            guard !ra.isEmpty else { throw .invalidCbor("readerAuthAll array is empty") }
             readerAuthAllRawCBOR = ra
             do { readerAuthAll = try ra.map { try ReaderAuth(cbor: $0) } } catch { throw .invalidCbor("readerAuthAll") }
         }

--- a/Sources/MdocDataModel18013/MdocRequest/DeviceRequest.swift
+++ b/Sources/MdocDataModel18013/MdocRequest/DeviceRequest.swift
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2023 European Commission
+Copyright (c) 2026 European Commission
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/Sources/MdocDataModel18013/MdocRequest/DeviceRequest.swift
+++ b/Sources/MdocDataModel18013/MdocRequest/DeviceRequest.swift
@@ -78,15 +78,15 @@ extension DeviceRequest: CBOREncodable {
     public func encode(options: CBOROptions) -> [UInt8] { toCBOR(options: options).encode(options: options) }
 
 	public func toCBOR(options: CBOROptions) -> CBOR {
-		var m = OrderedDictionary<CBOR, CBOR>()
-        m[.utf8String(Keys.version.rawValue)] = .utf8String(version)
-        m[.utf8String(Keys.docRequests.rawValue)] = .array(docRequests.map { $0.toCBOR(options: options) })
+		var map = OrderedDictionary<CBOR, CBOR>()
+        map[.utf8String(Keys.version.rawValue)] = .utf8String(version)
+        map[.utf8String(Keys.docRequests.rawValue)] = .array(docRequests.map { $0.toCBOR(options: options) })
         if let deviceRequestInfo {
             let bytes = deviceRequestInfo.toCBOR(options: options).encode(options: options)
-            m[.utf8String(Keys.deviceRequestInfo.rawValue)] = .tagged(.encodedCBORDataItem, .byteString(bytes))
+            map[.utf8String(Keys.deviceRequestInfo.rawValue)] = .tagged(.encodedCBORDataItem, .byteString(bytes))
         }
-        if let readerAuthAll { m[.utf8String(Keys.readerAuthAll.rawValue)] = readerAuthAll.toCBOR(options: options) }
-		return .map(m)
+        if let readerAuthAll { map[.utf8String(Keys.readerAuthAll.rawValue)] = readerAuthAll.toCBOR(options: options) }
+		return .map(map)
 	}
 }
 

--- a/Sources/MdocDataModel18013/MdocRequest/DeviceRequest.swift
+++ b/Sources/MdocDataModel18013/MdocRequest/DeviceRequest.swift
@@ -55,8 +55,8 @@ extension DeviceRequest: CBORDecodable {
     public init(cbor: CBOR) throws(MdocValidationError) {
         guard case let .map(m) = cbor else { throw .invalidCbor("device request") }
         guard case let .utf8String(v) = m[Keys.version] else { throw .missingField("DeviceRequest", Keys.version.rawValue) }
+        try MdocVersion.validateDeviceVersion(v, component: "device request")
         version = v
-		if v.count == 0 || v.prefix(1) != "1" { throw .invalidCbor("device request") }
         guard case let .array(cdrs) = m[Keys.docRequests] else { throw .missingField("DeviceRequest", Keys.docRequests.rawValue) }
         do { docRequests = try cdrs.map { try DocRequest(cbor: $0) } } catch { throw .invalidCbor("device request") }
         guard docRequests.count > 0 else { throw .invalidCbor("device request") }

--- a/Sources/MdocDataModel18013/MdocRequest/DeviceRequestInfo.swift
+++ b/Sources/MdocDataModel18013/MdocRequest/DeviceRequestInfo.swift
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2023 European Commission
+Copyright (c) 2026 European Commission
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/Sources/MdocDataModel18013/MdocRequest/DeviceRequestInfo.swift
+++ b/Sources/MdocDataModel18013/MdocRequest/DeviceRequestInfo.swift
@@ -62,8 +62,10 @@ extension UseCase: CBORDecodable {
         mandatory = b
         guard let docSetsValue = m[Keys.documentSets] else { throw .missingField("UseCase", Keys.documentSets.rawValue) }
         guard case let .array(arr) = docSetsValue else { throw .invalidCbor("UseCase") }
+        guard !arr.isEmpty else { throw .invalidCbor("UseCase.documentSets empty array") }
         documentSets = try arr.map { cbor  throws(MdocValidationError) in
             guard case let .array(docArray) = cbor else { throw MdocValidationError.invalidCbor("DocumentSet") }
+            guard !docArray.isEmpty else { throw MdocValidationError.invalidCbor("DocumentSet") }
             return try docArray.map { cborItem  throws(MdocValidationError) in
                 guard case let .unsignedInt(id) = cborItem else { throw MdocValidationError.invalidCbor("DocRequestID") }
                 return UInt(id)
@@ -147,6 +149,7 @@ extension DeviceRequestInfo: CBORDecodable {
         guard case let .map(m) = cbor else { throw .invalidCbor("DeviceRequestInfo") }
         if let useCasesValue = m[Keys.useCases] {
             guard case let .array(arr) = useCasesValue else { throw .invalidCbor("DeviceRequestInfo") }
+            guard !arr.isEmpty else { throw .invalidCbor("DeviceRequestInfo.useCases") }
             useCases = try arr.map { u throws(MdocValidationError) in try UseCase(cbor: u) }
         } else { useCases = nil }
         // Parse extensions (other keys in the map)

--- a/Sources/MdocDataModel18013/MdocRequest/DeviceRequestInfo.swift
+++ b/Sources/MdocDataModel18013/MdocRequest/DeviceRequestInfo.swift
@@ -39,13 +39,13 @@ public struct UseCase: Sendable {
     public let documentSets: [DocumentSet]
     public let purposeHints: PurposeHints?
     public let extensions: OrderedDictionary<String, CBOR>?
-    
+
     enum Keys: String {
         case mandatory
         case documentSets
         case purposeHints
     }
-    
+
     public init(mandatory: Bool, documentSets: [DocumentSet], purposeHints: PurposeHints? = nil, extensions: OrderedDictionary<String, CBOR>? = nil) {
         self.mandatory = mandatory
         self.documentSets = documentSets
@@ -86,7 +86,7 @@ extension UseCase: CBORDecodable {
         } else {
             purposeHints = nil
         }
-        
+
         // Parse extensions (other keys in the map)
         var exts: OrderedDictionary<String, CBOR>? = nil
         for (key, value) in m {
@@ -104,9 +104,9 @@ extension UseCase: CBORDecodable {
 
 extension UseCase: CBOREncodable {
     public func toCBOR(options: CBOROptions) -> CBOR {
-        var m = OrderedDictionary<CBOR, CBOR>()
-        m[.utf8String(Keys.mandatory.rawValue)] = .boolean(mandatory)
-        m[.utf8String(Keys.documentSets.rawValue)] = .array(
+        var map = OrderedDictionary<CBOR, CBOR>()
+        map[.utf8String(Keys.mandatory.rawValue)] = .boolean(mandatory)
+        map[.utf8String(Keys.documentSets.rawValue)] = .array(
             documentSets.map { docSet in
                 .array(docSet.map { .unsignedInt(UInt64($0)) })
             }
@@ -116,14 +116,14 @@ extension UseCase: CBOREncodable {
             for (controllerId, code) in purposeHints {
                 hintsMap[.utf8String(controllerId)] = code >= 0 ? .unsignedInt(UInt64(code)) : .negativeInt(UInt64(-code - 1))
             }
-            m[.utf8String(Keys.purposeHints.rawValue)] = .map(hintsMap)
+            map[.utf8String(Keys.purposeHints.rawValue)] = .map(hintsMap)
         }
         if let extensions {
             for (key, value) in extensions {
-                m[.utf8String(key)] = value
+                map[.utf8String(key)] = value
             }
-        }    
-        return .map(m)
+        }
+        return .map(map)
     }
 }
 
@@ -131,11 +131,11 @@ extension UseCase: CBOREncodable {
 public struct DeviceRequestInfo: Sendable {
     public let useCases: [UseCase]?
     public let extensions: OrderedDictionary<String, CBOR>?
-    
+
     enum Keys: String {
         case useCases
     }
-    
+
     public init(useCases: [UseCase]? = nil, extensions: OrderedDictionary<String, CBOR>? = nil) {
         self.useCases = useCases
         self.extensions = extensions
@@ -144,7 +144,7 @@ public struct DeviceRequestInfo: Sendable {
 
 extension DeviceRequestInfo: CBORDecodable {
     public init(cbor: CBOR) throws(MdocValidationError) {
-        guard case let .map(m) = cbor else { throw .invalidCbor("DeviceRequestInfo") }    
+        guard case let .map(m) = cbor else { throw .invalidCbor("DeviceRequestInfo") }
         if let useCasesValue = m[Keys.useCases] {
             guard case let .array(arr) = useCasesValue else { throw .invalidCbor("DeviceRequestInfo") }
             useCases = try arr.map { u throws(MdocValidationError) in try UseCase(cbor: u) }
@@ -163,17 +163,17 @@ extension DeviceRequestInfo: CBORDecodable {
 
 extension DeviceRequestInfo: CBOREncodable {
     public func toCBOR(options: CBOROptions) -> CBOR {
-        var m = OrderedDictionary<CBOR, CBOR>()      
+        var map = OrderedDictionary<CBOR, CBOR>()
         if let useCases {
-            m[.utf8String(Keys.useCases.rawValue)] = .array(
+            map[.utf8String(Keys.useCases.rawValue)] = .array(
                 useCases.map { $0.toCBOR(options: options) }
             )
         }
         if let extensions {
             for (key, value) in extensions {
-                m[.utf8String(key)] = value
+                map[.utf8String(key)] = value
             }
         }
-        return .map(m)
+        return .map(map)
     }
 }

--- a/Sources/MdocDataModel18013/MdocRequest/DocRequest.swift
+++ b/Sources/MdocDataModel18013/MdocRequest/DocRequest.swift
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2023 European Commission
+Copyright (c) 2026 European Commission
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/Sources/MdocDataModel18013/MdocRequest/DocRequest.swift
+++ b/Sources/MdocDataModel18013/MdocRequest/DocRequest.swift
@@ -44,11 +44,11 @@ extension DocRequest: CBORDecodable {
 
 extension DocRequest: CBOREncodable {
 	public func toCBOR(options: CBOROptions) -> CBOR {
-        var m = OrderedDictionary<CBOR, CBOR>()
-		if let itemsRequestRawData { m[.utf8String(Keys.itemsRequest.rawValue)] = itemsRequestRawData.taggedEncoded }
-        else { m[.utf8String(Keys.itemsRequest.rawValue)] = itemsRequest.toCBOR(options: options).taggedEncoded }
-        if let readerAuth { m[.utf8String(Keys.readerAuth.rawValue)] = readerAuth.toCBOR(options: options) }
-        return .map(m)
+        var map = OrderedDictionary<CBOR, CBOR>()
+		if let itemsRequestRawData { map[.utf8String(Keys.itemsRequest.rawValue)] = itemsRequestRawData.taggedEncoded }
+        else { map[.utf8String(Keys.itemsRequest.rawValue)] = itemsRequest.toCBOR(options: options).taggedEncoded }
+        if let readerAuth { map[.utf8String(Keys.readerAuth.rawValue)] = readerAuth.toCBOR(options: options) }
+        return .map(map)
     }
 }
 

--- a/Sources/MdocDataModel18013/MdocRequest/DocRequestInfo.swift
+++ b/Sources/MdocDataModel18013/MdocRequest/DocRequestInfo.swift
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2023 European Commission
+Copyright (c) 2026 European Commission
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/Sources/MdocDataModel18013/MdocRequest/DocRequestInfo.swift
+++ b/Sources/MdocDataModel18013/MdocRequest/DocRequestInfo.swift
@@ -31,7 +31,7 @@ public typealias MaximumResponseSize = UInt
 public struct ElementReference: Sendable, Equatable {
     public let nameSpace: NameSpace
     public let dataElementIdentifier: DataElementIdentifier
-    
+
     public init(nameSpace: NameSpace, dataElementIdentifier: DataElementIdentifier) {
         self.nameSpace = nameSpace
         self.dataElementIdentifier = dataElementIdentifier
@@ -65,12 +65,12 @@ public struct AlternativeDataElementsSet: Sendable {
     public let requestedElement: ElementReference
     public let alternativeElementSets: [AlternativeElementSet]
     public let extensions: OrderedDictionary<String, CBOR>?
-    
+
     enum Keys: String {
         case requestedElement
         case alternativeElementSets
     }
-    
+
     public init(requestedElement: ElementReference, alternativeElementSets: [AlternativeElementSet], extensions: OrderedDictionary<String, CBOR>? = nil) {
         self.requestedElement = requestedElement
         self.alternativeElementSets = alternativeElementSets
@@ -83,14 +83,14 @@ extension AlternativeDataElementsSet: CBORDecodable {
         guard case let .map(m) = cbor else { throw .invalidCbor("AlternativeDataElementsSet") }
         guard let reqElem = m[Keys.requestedElement] else { throw .missingField("AlternativeDataElementsSet", Keys.requestedElement.rawValue) }
         requestedElement = try ElementReference(cbor: reqElem)
-        
+
         guard let altElemSets = m[Keys.alternativeElementSets] else { throw .missingField("AlternativeDataElementsSet", Keys.alternativeElementSets.rawValue) }
         guard case let .array(arr) = altElemSets else { throw .invalidCbor("AlternativeDataElementsSet") }
         alternativeElementSets = try arr.map { cborSet throws(MdocValidationError) in
             guard case let .array(setArr) = cborSet else { throw MdocValidationError.invalidCbor("AlternativeElementSet") }
             return try setArr.map { e throws(MdocValidationError) in try ElementReference(cbor: e) }
         }
-        
+
         // Parse extensions (other keys in the map)
         var exts: OrderedDictionary<String, CBOR>? = nil
         for (key, value) in m {
@@ -105,19 +105,19 @@ extension AlternativeDataElementsSet: CBORDecodable {
 
 extension AlternativeDataElementsSet: CBOREncodable {
     public func toCBOR(options: CBOROptions) -> CBOR {
-        var m = OrderedDictionary<CBOR, CBOR>()
-        m[.utf8String(Keys.requestedElement.rawValue)] = requestedElement.toCBOR(options: options)
-        m[.utf8String(Keys.alternativeElementSets.rawValue)] = .array(
+        var map = OrderedDictionary<CBOR, CBOR>()
+        map[.utf8String(Keys.requestedElement.rawValue)] = requestedElement.toCBOR(options: options)
+        map[.utf8String(Keys.alternativeElementSets.rawValue)] = .array(
             alternativeElementSets.map { set in
                 .array(set.map { $0.toCBOR(options: options) })
             }
         )
         if let extensions {
             for (key, value) in extensions {
-                m[.utf8String(key)] = value
+                map[.utf8String(key)] = value
             }
         }
-        return .map(m)
+        return .map(map)
     }
 }
 
@@ -129,7 +129,7 @@ public struct DocRequestInfo: Sendable {
     public let maximumResponseSize: MaximumResponseSize?
     public let zkRequest: ZkRequest?
     public let extensions: OrderedDictionary<String, CBOR>?
-    
+
     enum Keys: String {
         case alternativeDataElements
         case issuerIdentifiers
@@ -137,7 +137,7 @@ public struct DocRequestInfo: Sendable {
         case maximumResponseSize
         case zkRequest
     }
-    
+
     public init(alternativeDataElements: [AlternativeDataElementsSet]? = nil, issuerIdentifiers: [IssuerIdentifier]? = nil, uniqueDocSetRequired: UniqueDocSetRequired? = nil, maximumResponseSize: MaximumResponseSize? = nil, zkRequest: ZkRequest? = nil, extensions: OrderedDictionary<String, CBOR>? = nil) {
         self.alternativeDataElements = alternativeDataElements
         self.issuerIdentifiers = issuerIdentifiers
@@ -177,7 +177,7 @@ extension DocRequestInfo: CBORDecodable {
         // parse zkRequest
         if let zkReq = m[Keys.zkRequest] {
             zkRequest = try ZkRequest(cbor: zkReq)
-        } else { zkRequest = nil }        
+        } else { zkRequest = nil }
         // Parse extensions (other keys in the map)
         var exts: OrderedDictionary<String, CBOR>? = nil
         for (key, value) in m {
@@ -197,37 +197,37 @@ extension DocRequestInfo: CBORDecodable {
 
 extension DocRequestInfo: CBOREncodable {
     public func toCBOR(options: CBOROptions) -> CBOR {
-        var m = OrderedDictionary<CBOR, CBOR>()
+        var map = OrderedDictionary<CBOR, CBOR>()
         // encode alternativeDataElements
         if let altData = alternativeDataElements {
-            m[.utf8String(Keys.alternativeDataElements.rawValue)] = .array(
+            map[.utf8String(Keys.alternativeDataElements.rawValue)] = .array(
                 altData.map { $0.toCBOR(options: options) }
             )
         }
         // encode issuerIdentifiers
         if let issuerIds = issuerIdentifiers {
-            m[.utf8String(Keys.issuerIdentifiers.rawValue)] = .array(
+            map[.utf8String(Keys.issuerIdentifiers.rawValue)] = .array(
                 issuerIds.map { .byteString($0) }
             )
         }
         // encode uniqueDocSetRequired
         if let uniqueDoc = uniqueDocSetRequired {
-            m[.utf8String(Keys.uniqueDocSetRequired.rawValue)] = .boolean(uniqueDoc)
+            map[.utf8String(Keys.uniqueDocSetRequired.rawValue)] = .boolean(uniqueDoc)
         }
         // encode maximumResponseSize
         if let maxResponse = maximumResponseSize {
-            m[.utf8String(Keys.maximumResponseSize.rawValue)] = .unsignedInt(UInt64(maxResponse))
+            map[.utf8String(Keys.maximumResponseSize.rawValue)] = .unsignedInt(UInt64(maxResponse))
         }
         // encode zkRequest
         if let zkReq = zkRequest {
-            m[.utf8String(Keys.zkRequest.rawValue)] = zkReq.toCBOR(options: options)
+            map[.utf8String(Keys.zkRequest.rawValue)] = zkReq.toCBOR(options: options)
         }
         // encode extensions
         if let extensions {
             for (key, value) in extensions {
-                m[.utf8String(key)] = value
+                map[.utf8String(key)] = value
             }
         }
-        return .map(m)
+        return .map(map)
     }
 }

--- a/Sources/MdocDataModel18013/MdocRequest/ItemsRequest.swift
+++ b/Sources/MdocDataModel18013/MdocRequest/ItemsRequest.swift
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2023 European Commission
+Copyright (c) 2026 European Commission
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/Sources/MdocDataModel18013/MdocRequest/ItemsRequest.swift
+++ b/Sources/MdocDataModel18013/MdocRequest/ItemsRequest.swift
@@ -46,10 +46,10 @@ extension ItemsRequest: CBORDecodable {
 
 extension ItemsRequest: CBOREncodable {
 	public func toCBOR(options: CBOROptions) -> CBOR {
-		var m = OrderedDictionary<CBOR, CBOR>()
-        m[.utf8String(Keys.docType.rawValue)] = .utf8String(docType)
-        m[.utf8String(Keys.nameSpaces.rawValue)] = requestNameSpaces.toCBOR(options: options)
-        if let requestInfo { m[.utf8String(Keys.requestInfo.rawValue)] = requestInfo.toCBOR(options: options) }
-		return .map(m)
+		var map = OrderedDictionary<CBOR, CBOR>()
+        map[.utf8String(Keys.docType.rawValue)] = .utf8String(docType)
+        map[.utf8String(Keys.nameSpaces.rawValue)] = requestNameSpaces.toCBOR(options: options)
+        if let requestInfo { map[.utf8String(Keys.requestInfo.rawValue)] = requestInfo.toCBOR(options: options) }
+		return .map(map)
 	}
 }

--- a/Sources/MdocDataModel18013/MdocRequest/ReaderAuth.swift
+++ b/Sources/MdocDataModel18013/MdocRequest/ReaderAuth.swift
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2023 European Commission
+Copyright (c) 2026 European Commission
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/Sources/MdocDataModel18013/MdocRequest/RequestDataElements.swift
+++ b/Sources/MdocDataModel18013/MdocRequest/RequestDataElements.swift
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2023 European Commission
+Copyright (c) 2026 European Commission
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/Sources/MdocDataModel18013/MdocRequest/RequestDataElements.swift
+++ b/Sources/MdocDataModel18013/MdocRequest/RequestDataElements.swift
@@ -43,9 +43,9 @@ extension RequestDataElements: CBORDecodable {
 
 extension RequestDataElements: CBOREncodable {
 	public func toCBOR(options: CBOROptions) -> CBOR {
-		let m = dataElements.map { (dei: DataElementIdentifier, ir: IntentToRetain) -> (CBOR, CBOR) in
+		let map = dataElements.map { (dei: DataElementIdentifier, ir: IntentToRetain) -> (CBOR, CBOR) in
 			(.utf8String(dei), .boolean(ir))
 		}
-		return .map(OrderedDictionary(m, uniquingKeysWith: { (d, _) in d }))
+		return .map(OrderedDictionary(map, uniquingKeysWith: { (d, _) in d }))
 	}
 }

--- a/Sources/MdocDataModel18013/MdocRequest/RequestNameSpaces.swift
+++ b/Sources/MdocDataModel18013/MdocRequest/RequestNameSpaces.swift
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2023 European Commission
+Copyright (c) 2026 European Commission
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/Sources/MdocDataModel18013/MdocRequest/RequestNameSpaces.swift
+++ b/Sources/MdocDataModel18013/MdocRequest/RequestNameSpaces.swift
@@ -41,9 +41,9 @@ extension RequestNameSpaces: CBORDecodable {
 
 extension RequestNameSpaces: CBOREncodable {
 	public func toCBOR(options: CBOROptions) -> CBOR {
-		let m = nameSpaces.map { (ns: NameSpace, rde: RequestDataElements) -> (CBOR, CBOR) in
+		let map = nameSpaces.map { (ns: NameSpace, rde: RequestDataElements) -> (CBOR, CBOR) in
 			(.utf8String(ns), rde.toCBOR(options: options))
 		}
-		return .map(OrderedDictionary(m, uniquingKeysWith: { (d, _) in d }))
+		return .map(OrderedDictionary(map, uniquingKeysWith: { (d, _) in d }))
 	}
 }

--- a/Sources/MdocDataModel18013/MdocRequest/ZkRequest.swift
+++ b/Sources/MdocDataModel18013/MdocRequest/ZkRequest.swift
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2023 European Commission
+Copyright (c) 2026 European Commission
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/Sources/MdocDataModel18013/MdocRequest/ZkRequest.swift
+++ b/Sources/MdocDataModel18013/MdocRequest/ZkRequest.swift
@@ -22,11 +22,11 @@ import OrderedCollections
 public struct ZkRequest: Sendable {
     public let systemSpecs: [ZkSystemSpec]
     public let extensions: OrderedDictionary<String, CBOR>?
-    
+
     enum Keys: String {
         case systemSpecs
     }
-    
+
     public init(systemSpecs: [ZkSystemSpec], extensions: OrderedDictionary<String, CBOR>? = nil) {
         self.systemSpecs = systemSpecs
         self.extensions = extensions
@@ -58,17 +58,17 @@ extension ZkRequest: CBORDecodable {
 
 extension ZkRequest: CBOREncodable {
     public func toCBOR(options: CBOROptions) -> CBOR {
-        var m = OrderedDictionary<CBOR, CBOR>()
+        var map = OrderedDictionary<CBOR, CBOR>()
         // encode systemSpecs
-        m[.utf8String(Keys.systemSpecs.rawValue)] = .array(
+        map[.utf8String(Keys.systemSpecs.rawValue)] = .array(
             systemSpecs.map { $0.toCBOR(options: options) }
         )
         // encode extensions
         if let extensions {
             for (key, value) in extensions {
-                m[.utf8String(key)] = value
+                map[.utf8String(key)] = value
             }
-        }   
-        return .map(m)
+        }
+        return .map(map)
     }
 }

--- a/Sources/MdocDataModel18013/MdocResponse/DeviceAuth.swift
+++ b/Sources/MdocDataModel18013/MdocResponse/DeviceAuth.swift
@@ -34,13 +34,13 @@ public struct DeviceAuth: Sendable {
 extension DeviceAuth: CBORDecodable {
 	public init(cbor: CBOR) throws(MdocValidationError) {
 		guard case let .map(m) = cbor else { throw .invalidCbor("Device authentication must be a map") }
-		let cs = m[Keys.deviceSignature]
-		let cm = m[Keys.deviceMac]
-		switch (cs, cm) {
-		case let (cs?, nil):
-			if let ds = Cose(type: .sign1, cbor: cs) { coseMacOrSignature = ds } else { throw .invalidCbor("Device authentication invalid DeviceSignature") }
-		case let (nil, cm?):
-			if let dm = Cose(type: .mac0, cbor: cm) { coseMacOrSignature = dm } else { throw .invalidCbor("Device authentication invalid DeviceMac") }
+		let deviceSignature = m[Keys.deviceSignature]
+		let deviceMac = m[Keys.deviceMac]
+		switch (deviceSignature, deviceMac) {
+		case let (coseDs?, nil):
+			if let dsign = Cose(type: .sign1, cbor: coseDs) { coseMacOrSignature = dsign } else { throw .invalidCbor("Device authentication invalid DeviceSignature") }
+		case let (nil, coseDm?):
+			if let dmac = Cose(type: .mac0, cbor: coseDm) { coseMacOrSignature = dmac } else { throw .invalidCbor("Device authentication invalid DeviceMac") }
 		case (.some, .some):
 			throw .invalidCbor("DeviceMac and DeviceSignature cannot both be present")
 		case (nil, nil):
@@ -51,13 +51,13 @@ extension DeviceAuth: CBORDecodable {
 
 extension DeviceAuth: CBOREncodable {
 	public func toCBOR(options: CBOROptions) -> CBOR {
-		var m = OrderedDictionary<CBOR, CBOR>()
+		var map = OrderedDictionary<CBOR, CBOR>()
 		let cborMS = coseMacOrSignature.toCBOR(options: options)
 		switch coseMacOrSignature.type {
-		case .sign1: m[.utf8String(Keys.deviceSignature.rawValue)] = cborMS
-		case .mac0: m[.utf8String(Keys.deviceMac.rawValue)] = cborMS
+		case .sign1: map[.utf8String(Keys.deviceSignature.rawValue)] = cborMS
+		case .mac0: map[.utf8String(Keys.deviceMac.rawValue)] = cborMS
 		}
-		return CBOR.map(m)
+		return CBOR.map(map)
 	}
 }
 //  MacAlgorithm.swift

--- a/Sources/MdocDataModel18013/MdocResponse/DeviceAuth.swift
+++ b/Sources/MdocDataModel18013/MdocResponse/DeviceAuth.swift
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2023 European Commission
+Copyright (c) 2026 European Commission
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/Sources/MdocDataModel18013/MdocResponse/DeviceAuth.swift
+++ b/Sources/MdocDataModel18013/MdocResponse/DeviceAuth.swift
@@ -33,12 +33,19 @@ public struct DeviceAuth: Sendable {
 
 extension DeviceAuth: CBORDecodable {
 	public init(cbor: CBOR) throws(MdocValidationError) {
-		guard case let .map(m) = cbor else { throw .invalidCbor("device authentication") }
-		if let cs = m[Keys.deviceSignature] {
-			if let ds = Cose(type: .sign1, cbor: cs) { coseMacOrSignature = ds } else { throw .invalidCbor("device authentication") }
-		} else if let cm = m[Keys.deviceMac] {
-			if let dm = Cose(type: .mac0, cbor: cm) { coseMacOrSignature = dm } else { throw .invalidCbor("device authentication") }
-		} else { throw .invalidCbor("device authentication") }
+		guard case let .map(m) = cbor else { throw .invalidCbor("Device authentication must be a map") }
+		let cs = m[Keys.deviceSignature]
+		let cm = m[Keys.deviceMac]
+		switch (cs, cm) {
+		case let (cs?, nil):
+			if let ds = Cose(type: .sign1, cbor: cs) { coseMacOrSignature = ds } else { throw .invalidCbor("Device authentication invalid DeviceSignature") }
+		case let (nil, cm?):
+			if let dm = Cose(type: .mac0, cbor: cm) { coseMacOrSignature = dm } else { throw .invalidCbor("Device authentication invalid DeviceMac") }
+		case (.some, .some):
+			throw .invalidCbor("DeviceMac and DeviceSignature cannot both be present")
+		case (nil, nil):
+			throw .invalidCbor("Either DeviceMac or DeviceSignature must be present")
+		}
 	}
 }
 

--- a/Sources/MdocDataModel18013/MdocResponse/DeviceResponse.swift
+++ b/Sources/MdocDataModel18013/MdocResponse/DeviceResponse.swift
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2023 European Commission
+Copyright (c) 2026 European Commission
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/Sources/MdocDataModel18013/MdocResponse/DeviceResponse.swift
+++ b/Sources/MdocDataModel18013/MdocResponse/DeviceResponse.swift
@@ -60,6 +60,7 @@ extension DeviceResponse: CBORDecodable {
 	public init(cbor: CBOR) throws(MdocValidationError) {
 		guard case .map(let cd) = cbor else { throw .invalidCbor("device response") }
 		guard case .utf8String(let v) = cd[Keys.version] else { throw .missingField("DeviceResponse", Keys.version.rawValue) }
+		try MdocVersion.validateDeviceVersion(v, component: "device response")
 		version = v
 		if case let .array(ds) = cd[Keys.documents] {
 			let ds = try ds.map { d  throws(MdocValidationError) in try Document(cbor:d) }

--- a/Sources/MdocDataModel18013/MdocResponse/DeviceResponse.swift
+++ b/Sources/MdocDataModel18013/MdocResponse/DeviceResponse.swift
@@ -63,16 +63,19 @@ extension DeviceResponse: CBORDecodable {
 		try MdocVersion.validateDeviceVersion(versionString, component: "device response")
 		version = versionString
 		if case let .array(documentCbors) = cborMap[Keys.documents] {
+			guard !documentCbors.isEmpty else { throw .invalidCbor("DeviceResponse.documents empty array") }
 			let parsedDocuments = try documentCbors.map { documentCbor  throws(MdocValidationError) in try Document(cbor: documentCbor) }
-			if parsedDocuments.count > 0 { self.documents = parsedDocuments } else { self.documents = nil }
+			self.documents = parsedDocuments
 		} else { documents = nil }
 		if case let .array(zkDocumentCbors) = cborMap[Keys.zkDocuments] {
+			guard !zkDocumentCbors.isEmpty else { throw .invalidCbor("DeviceResponse.zkDocuments empty array") }
 			let parsedZkDocuments = try zkDocumentCbors.map { zkDocumentCbor throws(MdocValidationError) in try ZkDocument(cbor: zkDocumentCbor) }
-			if parsedZkDocuments.count > 0 { self.zkDocuments = parsedZkDocuments } else { self.zkDocuments = nil }
+			self.zkDocuments = parsedZkDocuments
 		} else { zkDocuments = nil }
 		if case let .array(documentErrorCbors) = cborMap[Keys.documentErrors] {
+			guard !documentErrorCbors.isEmpty else { throw .invalidCbor("DeviceResponse.documentErrors empty array") }
 			let parsedDocumentErrors = try documentErrorCbors.map { documentErrorCbor throws(MdocValidationError) in try DocumentError(cbor: documentErrorCbor) }
-			if parsedDocumentErrors.count > 0 { self.documentErrors = parsedDocumentErrors } else { self.documentErrors = nil }
+			self.documentErrors = parsedDocumentErrors
 		}  else { documentErrors = nil }
 		guard case .unsignedInt(let statusValue) = cborMap[Keys.status] else { throw .missingField("DeviceResponse", Keys.status.rawValue) }
 		status = statusValue

--- a/Sources/MdocDataModel18013/MdocResponse/DeviceResponse.swift
+++ b/Sources/MdocDataModel18013/MdocResponse/DeviceResponse.swift
@@ -58,24 +58,24 @@ public struct DeviceResponse: Sendable {
 
 extension DeviceResponse: CBORDecodable {
 	public init(cbor: CBOR) throws(MdocValidationError) {
-		guard case .map(let cd) = cbor else { throw .invalidCbor("device response") }
-		guard case .utf8String(let v) = cd[Keys.version] else { throw .missingField("DeviceResponse", Keys.version.rawValue) }
-		try MdocVersion.validateDeviceVersion(v, component: "device response")
-		version = v
-		if case let .array(ds) = cd[Keys.documents] {
-			let ds = try ds.map { d  throws(MdocValidationError) in try Document(cbor:d) }
-			if ds.count > 0 { self.documents = ds } else { self.documents = nil }
+		guard case .map(let cborMap) = cbor else { throw .invalidCbor("device response") }
+		guard case .utf8String(let versionString) = cborMap[Keys.version] else { throw .missingField("DeviceResponse", Keys.version.rawValue) }
+		try MdocVersion.validateDeviceVersion(versionString, component: "device response")
+		version = versionString
+		if case let .array(documentCbors) = cborMap[Keys.documents] {
+			let parsedDocuments = try documentCbors.map { documentCbor  throws(MdocValidationError) in try Document(cbor: documentCbor) }
+			if parsedDocuments.count > 0 { self.documents = parsedDocuments } else { self.documents = nil }
 		} else { documents = nil }
-		if case let .array(zkd) = cd[Keys.zkDocuments] {
-			let zk = try zkd.map { d throws(MdocValidationError) in try ZkDocument(cbor:d) }
-			if zk.count > 0 { self.zkDocuments = zk } else { self.zkDocuments = nil }
+		if case let .array(zkDocumentCbors) = cborMap[Keys.zkDocuments] {
+			let parsedZkDocuments = try zkDocumentCbors.map { zkDocumentCbor throws(MdocValidationError) in try ZkDocument(cbor: zkDocumentCbor) }
+			if parsedZkDocuments.count > 0 { self.zkDocuments = parsedZkDocuments } else { self.zkDocuments = nil }
 		} else { zkDocuments = nil }
-		if case let .array(are) = cd[Keys.documentErrors] {
-			let de = try are.map { d throws(MdocValidationError) in try DocumentError(cbor:d) }
-			if de.count > 0 { self.documentErrors = de } else { self.documentErrors = nil }
+		if case let .array(documentErrorCbors) = cborMap[Keys.documentErrors] {
+			let parsedDocumentErrors = try documentErrorCbors.map { documentErrorCbor throws(MdocValidationError) in try DocumentError(cbor: documentErrorCbor) }
+			if parsedDocumentErrors.count > 0 { self.documentErrors = parsedDocumentErrors } else { self.documentErrors = nil }
 		}  else { documentErrors = nil }
-		guard case .unsignedInt(let st) = cd[Keys.status] else { throw .missingField("DeviceResponse", Keys.status.rawValue) }
-		status = st
+		guard case .unsignedInt(let statusValue) = cborMap[Keys.status] else { throw .missingField("DeviceResponse", Keys.status.rawValue) }
+		status = statusValue
 	}
 }
 
@@ -83,9 +83,9 @@ extension DeviceResponse: CBOREncodable {
 	public func toCBOR(options: CBOROptions) -> CBOR {
 		var cbor = OrderedDictionary<CBOR, CBOR>()
 		cbor[.utf8String(Keys.version.rawValue)] = .utf8String(version)
-		if let ds = documents { cbor[.utf8String(Keys.documents.rawValue)] = ds.toCBOR(options: options) }
-		if let zk = zkDocuments { cbor[.utf8String(Keys.zkDocuments.rawValue)] = .array(zk.map {$0.toCBOR(options: options)}) }
-		if let de = documentErrors { cbor[.utf8String(Keys.documentErrors.rawValue)] = .array(de.map {$0.toCBOR(options: options)}) }
+		if let documents { cbor[.utf8String(Keys.documents.rawValue)] = documents.toCBOR(options: options) }
+		if let zkDocuments { cbor[.utf8String(Keys.zkDocuments.rawValue)] = .array(zkDocuments.map { $0.toCBOR(options: options) }) }
+		if let documentErrors { cbor[.utf8String(Keys.documentErrors.rawValue)] = .array(documentErrors.map { $0.toCBOR(options: options) }) }
 		cbor[.utf8String(Keys.status.rawValue)] = .unsignedInt(status)
 		return .map(cbor)
 	}

--- a/Sources/MdocDataModel18013/MdocResponse/DeviceSigned.swift
+++ b/Sources/MdocDataModel18013/MdocResponse/DeviceSigned.swift
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2023 European Commission
+Copyright (c) 2026 European Commission
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/Sources/MdocDataModel18013/MdocResponse/DeviceSigned.swift
+++ b/Sources/MdocDataModel18013/MdocResponse/DeviceSigned.swift
@@ -68,11 +68,11 @@ extension DeviceNameSpaces: CBORDecodable {
 		guard case let .map(m) = cbor else { throw .invalidCbor("device signed") }
 		let dnsPairs = try m.map { (k: CBOR, v: CBOR) throws(MdocValidationError) -> (NameSpace, DeviceSignedItems)  in
 			guard case .utf8String(let ns) = k else { throw .invalidCbor("device signed") }
-			let dsi = try DeviceSignedItems(cbor: v)
-			return (ns,dsi)
+			let deviceSignedItems = try DeviceSignedItems(cbor: v)
+			return (ns, deviceSignedItems)
 		}
-		let dns: [NameSpace : DeviceSignedItems] = Dictionary(dnsPairs, uniquingKeysWith: { (first, _) in first })
-		deviceNameSpaces = dns
+		let dsignItemsMap: [NameSpace : DeviceSignedItems] = Dictionary(dnsPairs, uniquingKeysWith: { (first, _) in first })
+		deviceNameSpaces = dsignItemsMap
 	}
 }
 

--- a/Sources/MdocDataModel18013/MdocResponse/DeviceSigned.swift
+++ b/Sources/MdocDataModel18013/MdocResponse/DeviceSigned.swift
@@ -90,7 +90,7 @@ extension DeviceSignedItems: CBORDecodable {
 			return (dei,v)
 		}
 		let dsi = Dictionary(dsiPairs, uniquingKeysWith: { (first, _) in first })
-		if dsi.count == 0 { throw .invalidCbor("device signed") }
+		guard !dsi.isEmpty else { throw .invalidCbor("device signed empty array") }
 		deviceSignedItems = dsi
 	}
 }

--- a/Sources/MdocDataModel18013/MdocResponse/DocDataValue.swift
+++ b/Sources/MdocDataModel18013/MdocResponse/DocDataValue.swift
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2023 European Commission
+Copyright (c) 2026 European Commission
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/Sources/MdocDataModel18013/MdocResponse/Document.swift
+++ b/Sources/MdocDataModel18013/MdocResponse/Document.swift
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2023 European Commission
+Copyright (c) 2026 European Commission
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/Sources/MdocDataModel18013/MdocResponse/DocumentError.swift
+++ b/Sources/MdocDataModel18013/MdocResponse/DocumentError.swift
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2023 European Commission
+Copyright (c) 2026 European Commission
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/Sources/MdocDataModel18013/MdocResponse/DocumentError.swift
+++ b/Sources/MdocDataModel18013/MdocResponse/DocumentError.swift
@@ -31,23 +31,23 @@ public struct DocumentError: Sendable {
 
 extension DocumentError: CBORDecodable {
 	public init(cbor: CBOR) throws(MdocValidationError) {
-		guard case let .map(e) = cbor else { throw MdocValidationError.invalidCbor("document error") }
-		let dePairs = try e.map { (k: CBOR, v: CBOR) throws(MdocValidationError) -> (DocType, ErrorCode)  in
-			guard case .utf8String(let dt) = k else { throw .invalidCbor("document error") }
-			guard case .unsignedInt(let ec) = v else { throw .invalidCbor("document error") }
-			return (dt,ec)
+		guard case let .map(errorMap) = cbor else { throw MdocValidationError.invalidCbor("document error") }
+		let docErrorPairs = try errorMap.map { (key: CBOR, value: CBOR) throws(MdocValidationError) -> (DocType, ErrorCode)  in
+			guard case .utf8String(let docType) = key else { throw .invalidCbor("document error") }
+			guard case .unsignedInt(let errorCode) = value else { throw .invalidCbor("document error") }
+			return (docType, errorCode)
 		}
-		let de = Dictionary(dePairs, uniquingKeysWith: { (first, _) in first })
-		if de.count == 0 { throw .invalidCbor("document error") }
-		docErrors = de
+		let docErrorsMap = Dictionary(docErrorPairs, uniquingKeysWith: { (first, _) in first })
+		if docErrorsMap.count == 0 { throw .invalidCbor("document error") }
+		docErrors = docErrorsMap
 	}
 }
 
 extension DocumentError: CBOREncodable {
 	public func toCBOR(options: CBOROptions) -> CBOR {
-		let m = docErrors.map { (dt: DocType, ec: ErrorCode) -> (CBOR, CBOR) in
-			(.utf8String(dt), .unsignedInt(ec))
+		let entries = docErrors.map { (docType: DocType, errorCode: ErrorCode) -> (CBOR, CBOR) in
+			(.utf8String(docType), .unsignedInt(errorCode))
 		}
-		return .map(OrderedDictionary(m, uniquingKeysWith: { (d, _) in d }))
+		return .map(OrderedDictionary(entries, uniquingKeysWith: { (key, _) in key }))
 	}
 }

--- a/Sources/MdocDataModel18013/MdocResponse/Errors.swift
+++ b/Sources/MdocDataModel18013/MdocResponse/Errors.swift
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2023 European Commission
+Copyright (c) 2026 European Commission
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/Sources/MdocDataModel18013/MdocResponse/Errors.swift
+++ b/Sources/MdocDataModel18013/MdocResponse/Errors.swift
@@ -32,34 +32,34 @@ public struct Errors: Sendable {
 
 extension Errors: CBORDecodable {
 	public init(cbor: CBOR) throws(MdocValidationError) {
-        guard case let .map(e) = cbor else { throw .invalidCbor("errors") }
-        if e.count == 0 { throw .invalidCbor("errors") }
-        let pairs = try e.map { (key: CBOR, value: CBOR) throws(MdocValidationError) -> (NameSpace, ErrorItems) in
+        guard case let .map(errorMap) = cbor else { throw .invalidCbor("errors") }
+        if errorMap.count == 0 { throw .invalidCbor("errors") }
+        let namespacePairs = try errorMap.map { (key: CBOR, value: CBOR) throws(MdocValidationError) -> (NameSpace, ErrorItems) in
             guard case .utf8String(let ns) = key else { throw .invalidCbor("errors") }
-            guard case .map(let m) = value else { throw .invalidCbor("errors") }
-            let eiPairs = try m.map { (k: CBOR, v: CBOR) throws(MdocValidationError) -> (DataElementIdentifier, ErrorCode) in
-                guard case .utf8String(let dei) = k else { throw .invalidCbor("errors") }
-                guard case .unsignedInt(let ec) = v else { throw .invalidCbor("errors") }
-                return (dei, ec)
+            guard case .map(let namespaceItemMap) = value else { throw .invalidCbor("errors") }
+            let errorItemPairs = try namespaceItemMap.map { (key: CBOR, value: CBOR) throws(MdocValidationError) -> (DataElementIdentifier, ErrorCode) in
+                guard case .utf8String(let dataElementIdentifier) = key else { throw .invalidCbor("errors") }
+                guard case .unsignedInt(let errorCode) = value else { throw .invalidCbor("errors") }
+                return (dataElementIdentifier, errorCode)
             }
-            let ei = Dictionary(eiPairs, uniquingKeysWith: { (first, _) in first })
-            if ei.count == 0 { throw .invalidCbor("errors") }
-            return (ns, ei)
+            let errorItems = Dictionary(errorItemPairs, uniquingKeysWith: { (first, _) in first })
+            if errorItems.count == 0 { throw .invalidCbor("errors") }
+            return (ns, errorItems)
         }
-        errors = Dictionary(pairs, uniquingKeysWith: { (first, _) in first })
+        errors = Dictionary(namespacePairs, uniquingKeysWith: { (first, _) in first })
     }
 }
 
 extension Errors: CBOREncodable {
 	public func toCBOR(options: CBOROptions) -> CBOR {
-        let map1 = errors.map { (ns: NameSpace, ei: ErrorItems) -> (CBOR, CBOR) in
-            let kns = CBOR.utf8String(ns)
-            let mei = ei.map { (dei: DataElementIdentifier, ec: ErrorCode) -> (CBOR, CBOR) in
-                (.utf8String(dei), .unsignedInt(ec))
+        let namespaceMapEntries = errors.map { (ns: NameSpace, errorItems: ErrorItems) -> (CBOR, CBOR) in
+            let namespaceKey = CBOR.utf8String(ns)
+            let errorItemEntries = errorItems.map { (dataElementIdentifier: DataElementIdentifier, errorCode: ErrorCode) -> (CBOR, CBOR) in
+                (.utf8String(dataElementIdentifier), .unsignedInt(errorCode))
             }
-            return (kns, .map(OrderedDictionary(mei, uniquingKeysWith: { (d, _) in d })))
+            return (namespaceKey, .map(OrderedDictionary(errorItemEntries, uniquingKeysWith: { (key, _) in key })))
         }
-        let cborMap = OrderedDictionary(map1, uniquingKeysWith: { (ns, _) in ns })
+        let cborMap = OrderedDictionary(namespaceMapEntries, uniquingKeysWith: { (key, _) in key })
         return .map(cborMap)
     }
 }

--- a/Sources/MdocDataModel18013/MdocResponse/IssuerNameSpaces.swift
+++ b/Sources/MdocDataModel18013/MdocResponse/IssuerNameSpaces.swift
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2023 European Commission
+Copyright (c) 2026 European Commission
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/Sources/MdocDataModel18013/MdocResponse/IssuerNameSpaces.swift
+++ b/Sources/MdocDataModel18013/MdocResponse/IssuerNameSpaces.swift
@@ -35,6 +35,7 @@ extension IssuerNameSpaces: CBORDecodable {
 		var temp = [NameSpace: [IssuerSignedItem]]()
 		for (k,v) in m {
 			guard case let .utf8String(ns) = k, case let .array(ar) = v else { continue }
+			guard !ar.isEmpty else { throw .invalidCbor("issuer namespace '\(ns)' empty array") }
 			let items = try ar.map { c throws(MdocValidationError) -> IssuerSignedItem in
 				guard case let .tagged(tg, cbs) = c, tg == .encodedCBORDataItem, case let .byteString(bs) = cbs else {
                     throw .invalidCbor("issuer signed item '\(k)'")

--- a/Sources/MdocDataModel18013/MdocResponse/IssuerSigned.swift
+++ b/Sources/MdocDataModel18013/MdocResponse/IssuerSigned.swift
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2023 European Commission
+Copyright (c) 2026 European Commission
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/Sources/MdocDataModel18013/MdocResponse/IssuerSignedItem.swift
+++ b/Sources/MdocDataModel18013/MdocResponse/IssuerSignedItem.swift
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2023 European Commission
+Copyright (c) 2026 European Commission
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/Sources/MdocDataModel18013/MdocResponse/IssuerSignedItem.swift
+++ b/Sources/MdocDataModel18013/MdocResponse/IssuerSignedItem.swift
@@ -64,7 +64,7 @@ extension CBOR: @retroactive CustomDebugStringConvertible {
 				case .unsignedInt(let i): return String(i)
 				case .boolean(let b): return String(b)
 		case .array(let a): return "[\(a.reduce("", { $0 + ($0.count > 0 ? "," : "") + " \($1.debugDescription)" }))]"
-		case .map(let m): return "{\(m.reduce("", { $0 + ($0.count > 0 ? "," : "") + " \($1.key.debugDescription): \($1.value.debugDescription)" }))}"
+		case .map(let map): return "{\(map.reduce("", { $0 + ($0.count > 0 ? "," : "") + " \($1.key.debugDescription): \($1.value.debugDescription)" }))}"
 		case .null: return "Null"
 		case .simple(let n): return String(n)
 				default: return "Other"

--- a/Sources/MdocDataModel18013/MdocResponse/SignupResponse.swift
+++ b/Sources/MdocDataModel18013/MdocResponse/SignupResponse.swift
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2023 European Commission
+Copyright (c) 2026 European Commission
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/Sources/MdocDataModel18013/MdocResponse/ZkDocument.swift
+++ b/Sources/MdocDataModel18013/MdocResponse/ZkDocument.swift
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2023 European Commission
+Copyright (c) 2026 European Commission
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/Sources/MdocDataModel18013/MdocResponse/ZkDocumentData.swift
+++ b/Sources/MdocDataModel18013/MdocResponse/ZkDocumentData.swift
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2023 European Commission
+Copyright (c) 2026 European Commission
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/Sources/MdocDataModel18013/MdocValidationError.swift
+++ b/Sources/MdocDataModel18013/MdocValidationError.swift
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2023 European Commission
+Copyright (c) 2026 European Commission
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/Sources/MdocDataModel18013/MdocValidationError.swift
+++ b/Sources/MdocDataModel18013/MdocValidationError.swift
@@ -21,6 +21,7 @@ public enum MdocValidationError: LocalizedError, Sendable {
     case cborDecodingError
     case invalidCbor(String)
     case missingField(String, String)
+    case invalidDateTimeFormat(String, String)
 
     public var errorDescription: String? {
         switch self {
@@ -30,6 +31,8 @@ public enum MdocValidationError: LocalizedError, Sendable {
             return NSLocalizedString("Invalid CBOR format in \(component)", comment: "Error message for invalid CBOR format")
         case .missingField(let component, let field):
             return NSLocalizedString("Missing field in \(component): \(field)", comment: "Error message for missing field")
+        case .invalidDateTimeFormat(let component, let field):
+            return NSLocalizedString("Invalid date-time format in \(component): \(field) must not contain fractional seconds", comment: "Error message for invalid date-time format")
         }
     }
 }

--- a/Sources/MdocDataModel18013/MdocVersion.swift
+++ b/Sources/MdocDataModel18013/MdocVersion.swift
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2023 European Commission
+Copyright (c) 2026 European Commission
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/Sources/MdocDataModel18013/MdocVersion.swift
+++ b/Sources/MdocDataModel18013/MdocVersion.swift
@@ -1,0 +1,30 @@
+/*
+Copyright (c) 2023 European Commission
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import Foundation
+
+enum MdocVersion {
+	static let supportedDeviceVersions: Set<String> = [
+		"1.0",
+		"1.1",
+	]
+
+	static func validateDeviceVersion(_ version: String, component: String) throws(MdocValidationError) {
+		guard supportedDeviceVersions.contains(version) else {
+			throw .invalidCbor(component)
+		}
+	}
+}

--- a/Sources/MdocDataModel18013/SecureArea/CoseEcCurve.swift
+++ b/Sources/MdocDataModel18013/SecureArea/CoseEcCurve.swift
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2023 European Commission
+Copyright (c) 2026 European Commission
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/Sources/MdocDataModel18013/SecureArea/CredentialOptions.swift
+++ b/Sources/MdocDataModel18013/SecureArea/CredentialOptions.swift
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2023 European Commission
+Copyright (c) 2026 European Commission
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/Sources/MdocDataModel18013/SecureArea/CredentialPolicy.swift
+++ b/Sources/MdocDataModel18013/SecureArea/CredentialPolicy.swift
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2023 European Commission
+Copyright (c) 2026 European Commission
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/Sources/MdocDataModel18013/SecureArea/CredentialsUsageCounts.swift
+++ b/Sources/MdocDataModel18013/SecureArea/CredentialsUsageCounts.swift
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2023 European Commission
+Copyright (c) 2026 European Commission
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/Sources/MdocDataModel18013/SecureArea/DocKeyInfo.swift
+++ b/Sources/MdocDataModel18013/SecureArea/DocKeyInfo.swift
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2023 European Commission
+Copyright (c) 2026 European Commission
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/Sources/MdocDataModel18013/SecureArea/KeyBatchInfo.swift
+++ b/Sources/MdocDataModel18013/SecureArea/KeyBatchInfo.swift
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2023 European Commission
+Copyright (c) 2026 European Commission
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/Sources/MdocDataModel18013/SecureArea/KeyOptions.swift
+++ b/Sources/MdocDataModel18013/SecureArea/KeyOptions.swift
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2023 European Commission
+Copyright (c) 2026 European Commission
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/Sources/MdocDataModel18013/SecureArea/SecureArea.swift
+++ b/Sources/MdocDataModel18013/SecureArea/SecureArea.swift
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2023 European Commission
+Copyright (c) 2026 European Commission
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/Sources/MdocDataModel18013/SecureArea/SecureArea.swift
+++ b/Sources/MdocDataModel18013/SecureArea/SecureArea.swift
@@ -49,6 +49,8 @@ public protocol SecureArea: Actor {
     func signature(id: String, index: Int, algorithm: SigningAlgorithm, dataToSign: Data, unlockData: Data?) async throws -> Data
     /// make key-agreement (shared secret) with other public key (used for encryption and mac computations)
     func keyAgreement(id: String, index: Int, publicKey: CoseKey, unlockData: Data?) async throws -> SharedSecret
+    /// returns information about the key with the given id and the curve of the key
+    func getInfoAndCurve(id: String) async throws -> ([String:Data], CoseEcCurve) 
     /// returns information about the key with the given id
     func getKeyBatchInfo(id: String) async throws -> KeyBatchInfo
     /// return the storage instance
@@ -69,6 +71,13 @@ extension SecureArea {
     }
     public func defaultSigningAlgorithm(ecCurve: CoseEcCurve) -> SigningAlgorithm { ecCurve.defaultSigningAlgorithm }
 
+    public func getInfoAndCurve(id: String) async throws -> ([String:Data], CoseEcCurve) {
+        let storage = await getStorage()
+        let keyInfoDict = try await storage.readKeyInfo(id: id)
+        guard let jwkNameData = keyInfoDict[kSecAttrDescription as String], let jwkName = String(data: jwkNameData, encoding: .utf8) else { throw SecureAreaError("Key info description not found") }
+        let curve = try CoseEcCurve.fromJwkName(jwkName)
+        return (keyInfoDict, curve)
+    }
     /// returns information about the key with the given key
     public func getKeyBatchInfo(id: String) async throws -> KeyBatchInfo {
         let storage = await getStorage()

--- a/Sources/MdocDataModel18013/SecureArea/SecureAreaError.swift
+++ b/Sources/MdocDataModel18013/SecureArea/SecureAreaError.swift
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2023 European Commission
+Copyright (c) 2026 European Commission
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/Sources/MdocDataModel18013/SecureArea/SecureAreaRegistry.swift
+++ b/Sources/MdocDataModel18013/SecureArea/SecureAreaRegistry.swift
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2023 European Commission
+Copyright (c) 2026 European Commission
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/Sources/MdocDataModel18013/SecureArea/SecureKeyStorage.swift
+++ b/Sources/MdocDataModel18013/SecureArea/SecureKeyStorage.swift
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2023 European Commission
+Copyright (c) 2026 European Commission
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/Sources/MdocDataModel18013/Zkp/ZkParams.swift
+++ b/Sources/MdocDataModel18013/Zkp/ZkParams.swift
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2023 European Commission
+Copyright (c) 2026 European Commission
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/Sources/MdocDataModel18013/Zkp/ZkSystemSpec.swift
+++ b/Sources/MdocDataModel18013/Zkp/ZkSystemSpec.swift
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2023 European Commission
+Copyright (c) 2026 European Commission
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/Sources/MdocDataModel18013/Zkp/ZkSystemSpec.swift
+++ b/Sources/MdocDataModel18013/Zkp/ZkSystemSpec.swift
@@ -44,7 +44,7 @@ public struct ZkSystemSpec: Sendable, Identifiable {
 
 extension ZkSystemSpec: CBORDecodable {
     public init(cbor: CBOR) throws(MdocValidationError) {
-        guard case let .map(m) = cbor else { throw .invalidCbor("ZkSystemSpec") }   
+        guard case let .map(m) = cbor else { throw .invalidCbor("ZkSystemSpec") }
         guard let systemValue = m[Keys.system] else { throw .missingField("ZkSystemSpec", Keys.system.rawValue) }
         guard case let .utf8String(sys) = systemValue else { throw .invalidCbor("ZkSystemSpec") }
         system = sys
@@ -138,21 +138,21 @@ extension Array where Element == ZkSystemSpec {
 
 extension ZkSystemSpec: CBOREncodable {
     public func toCBOR(options: CBOROptions) -> CBOR {
-        var m = OrderedDictionary<CBOR, CBOR>()
-        m[.utf8String(Keys.system.rawValue)] = .utf8String(system)
+        var map = OrderedDictionary<CBOR, CBOR>()
+        map[.utf8String(Keys.system.rawValue)] = .utf8String(system)
         // encode params
         var paramsMap = OrderedDictionary<CBOR, CBOR>()
         for (key, value) in params {
             paramsMap[.utf8String(key)] = value.toCBOR(options: options)
         }
-        m[.utf8String(Keys.params.rawValue)] = .map(paramsMap)
+        map[.utf8String(Keys.params.rawValue)] = .map(paramsMap)
         // encode extensions
         if let extensions {
             for (key, value) in extensions {
-                m[.utf8String(key)] = value
+                map[.utf8String(key)] = value
             }
         }
-        
-        return .map(m)
+
+        return .map(map)
     }
 }

--- a/Sources/MdocDataModel18013/Zkp/ZkSystemSpec.swift
+++ b/Sources/MdocDataModel18013/Zkp/ZkSystemSpec.swift
@@ -21,19 +21,21 @@ import OrderedCollections
 
 /// ZkSystemSpec
 public struct ZkSystemSpec: Sendable, Identifiable {
-    public let id: String
+    public let zkSystemId: String
     public let system: ZkSystem
     public let params: ZkParams
     public let extensions: OrderedDictionary<String, CBOR>?
-    
+
+    public var id: String { zkSystemId }
+
     enum Keys: String {
-        case id
+        case zkSystemId
         case system
         case params
     }
-    
-    public init(id: String, system: ZkSystem, params: ZkParams, extensions: OrderedDictionary<String, CBOR>? = nil) {
-        self.id = id
+
+    public init(zkSystemId: String, system: ZkSystem, params: ZkParams, extensions: OrderedDictionary<String, CBOR>? = nil) {
+        self.zkSystemId = zkSystemId
         self.system = system
         self.params = params
         self.extensions = extensions
@@ -46,7 +48,7 @@ extension ZkSystemSpec: CBORDecodable {
         guard let systemValue = m[Keys.system] else { throw .missingField("ZkSystemSpec", Keys.system.rawValue) }
         guard case let .utf8String(sys) = systemValue else { throw .invalidCbor("ZkSystemSpec") }
         system = sys
-        if case let .utf8String(tid) = m[Keys.id] { id = tid } else { id = "\(sys)" }
+        if case let .utf8String(tid) = m[Keys.zkSystemId] { zkSystemId = tid } else { zkSystemId = sys }
         // decode params
         guard let paramsValue = m[Keys.params] else { throw .missingField("ZkSystemSpec", Keys.params.rawValue) }
         guard case let .map(paramsMap) = paramsValue else { throw .invalidCbor("ZkSystemSpec") }
@@ -79,13 +81,13 @@ extension ZkSystemSpec {
             throw MdocValidationError.missingField("ZkSystemSpec", Keys.system.rawValue)
         }
         self.system = sys
-        // Use explicit "id" if present, otherwise fall back to system value
-        if let idValue = jsonObject[Keys.id.rawValue].string { self.id = idValue } 
-        else { self.id = sys }
-        // All keys except "system" and "id" become params
+        // Use explicit "zkSystemId" if present, otherwise fall back to system value
+        if let idValue = jsonObject[Keys.zkSystemId.rawValue].string { self.zkSystemId = idValue }
+        else { self.zkSystemId = sys }
+        // All keys except "system" and "zkSystemId" become params
         var zkParams = OrderedDictionary<String, ZkParam>()
         for (key, value) in jsonObject {
-            guard key != Keys.system.rawValue, key != Keys.id.rawValue else { continue }
+            guard key != Keys.system.rawValue, key != Keys.zkSystemId.rawValue else { continue }
             zkParams[key] = try Self.zkParam(from: value, key: key)
         }
         self.params = zkParams

--- a/Tests/MdocDataModel18013Tests/InMemoryP256SecureArea.swift
+++ b/Tests/MdocDataModel18013Tests/InMemoryP256SecureArea.swift
@@ -1,5 +1,5 @@
 /*
- Copyright (c) 2023 European Commission
+ Copyright (c) 2026 European Commission
 
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.

--- a/Tests/MdocDataModel18013Tests/MdocDataModel18013Tests.swift
+++ b/Tests/MdocDataModel18013Tests/MdocDataModel18013Tests.swift
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2023 European Commission
+Copyright (c) 2026 European Commission
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/Tests/MdocDataModel18013Tests/MdocDataModel18013Tests.swift
+++ b/Tests/MdocDataModel18013Tests/MdocDataModel18013Tests.swift
@@ -228,6 +228,19 @@ struct MdocDataModel18013Tests {
         #expect(dr2.version == "1.0")
 	}
 
+	@Test func decodeDeviceAuthRejectsMutuallyExclusiveFields() throws {
+		let deviceSignature = Cose(type: .sign1, algorithm: Cose.VerifyAlgorithm.es256.rawValue, signature: Data([0x01]))
+		let deviceMac = Cose(type: .mac0, algorithm: Cose.MacAlgorithm.hmac256.rawValue, signature: Data([0x02]))
+		let cbor = CBOR.map([
+			.utf8String("deviceSignature"): deviceSignature.toCBOR(options: CBOROptions()),
+			.utf8String("deviceMac"): deviceMac.toCBOR(options: CBOROptions())
+		])
+
+		#expect(throws: MdocValidationError.self) {
+			try DeviceAuth(cbor: cbor)
+		}
+	}
+
   #if os(iOS)
     @Test func generateBLEengageQRCodeImage() async throws {
         var de = try #require(DeviceEngagement(isBleServer: true))

--- a/Tests/MdocDataModel18013Tests/MdocDataModel18013Tests.swift
+++ b/Tests/MdocDataModel18013Tests/MdocDataModel18013Tests.swift
@@ -316,7 +316,7 @@ struct MdocDataModel18013Tests {
 		let spec = try ZkSystemSpec(jsonData: jsonData)
 
 		#expect(spec.system == "longfellow-libzk-v1")
-		#expect(spec.id == "longfellow-libzk-v1")
+		#expect(spec.zkSystemId == "longfellow-libzk-v1")
 		#expect(spec.params["circuit_hash"]?.stringValue == "137e5a75ce72735a37c8a72da1a8a0a5df8d13365c2ae3d2c2bd6a0e7197c7c6")
 		#expect(spec.params["version"]?.intValue == 6)
 		#expect(spec.params["block_enc_hash"]?.intValue == 4096)

--- a/Tests/MdocDataModel18013Tests/MdocDataModel18013Tests.swift
+++ b/Tests/MdocDataModel18013Tests/MdocDataModel18013Tests.swift
@@ -21,8 +21,8 @@ import OrderedCollections
 @testable import MdocDataModel18013
 
 struct MdocDataModel18013Tests {
-	static let pkb64 = "pQECIAEhWCBoHIiBQnDRMLUT4yOLqJ1l8mrfNIgrjNnFq4RyZgxSmiJYIGD/Sabu6GejaR4eTiym1JkyjnBNcJ+f59pN+lCEyhVyI1ggC6EPCKyGci++LGWUX3fXpPFW6pYO8pyyKLMKs1qF0jo="
-    static let pk = CoseKeyPrivate(p256data: pkb64, privateKeyId: "someKeyId")!
+	static let privateKeyBase64 = "pQECIAEhWCBoHIiBQnDRMLUT4yOLqJ1l8mrfNIgrjNnFq4RyZgxSmiJYIGD/Sabu6GejaR4eTiym1JkyjnBNcJ+f59pN+lCEyhVyI1ggC6EPCKyGci++LGWUX3fXpPFW6pYO8pyyKLMKs1qF0jo="
+    static let privateKey = CoseKeyPrivate(p256data: privateKeyBase64, privateKeyId: "someKeyId")!
 
     @Test func basicExample() throws {
         // Swift Testing Documentation

--- a/Tests/MdocDataModel18013Tests/MdocDataModel18013Tests.swift
+++ b/Tests/MdocDataModel18013Tests/MdocDataModel18013Tests.swift
@@ -97,6 +97,16 @@ struct MdocDataModel18013Tests {
 		}
 	}
 
+	@Test func decodeDeviceRequestRejectsEmptyReaderAuthAllArray() throws {
+		let cbor = try mutatedTopLevelMapCBOR(from: Self.AnnexdTestData.d411.bytes) { map in
+			map[.utf8String("readerAuthAll")] = .array([])
+		}
+
+		#expect(throws: MdocValidationError.self) {
+			try DeviceRequest(cbor: cbor)
+		}
+	}
+
 	@Test func decodeSampleDataResponse() throws {
 		let eudiSampleData = Data(name: "EUDI_sample_data", ext: "json", from: Bundle.module)!
 		let sr = try #require(eudiSampleData.decodeJSON(type: SignUpResponse.self))
@@ -243,6 +253,38 @@ struct MdocDataModel18013Tests {
 		}
 	}
 
+	@Test func decodeDeviceResponseRejectsEmptyDocumentsArray() throws {
+		let cbor = try mutatedTopLevelMapCBOR(from: Self.AnnexdTestData.d412.bytes) { map in
+			map[.utf8String("documents")] = .array([])
+		}
+
+		#expect(throws: MdocValidationError.self) {
+			try DeviceResponse(cbor: cbor)
+		}
+	}
+
+	@Test func decodeDeviceResponseRejectsEmptyDocumentErrorsArray() throws {
+		let cbor = try mutatedTopLevelMapCBOR(from: Self.AnnexdTestData.d412.bytes) { map in
+			map[.utf8String("documentErrors")] = .array([])
+		}
+
+		#expect(throws: MdocValidationError.self) {
+			try DeviceResponse(cbor: cbor)
+		}
+	}
+
+	@Test func decodeIssuerSignedRejectsEmptyNamespaceItemsArray() throws {
+		let cbor = try mutatedIssuerSignedCBOR(from: Self.AnnexdTestData.d412.bytes) { issuerSignedMap in
+			issuerSignedMap[.utf8String("nameSpaces")] = .map([
+				.utf8String(IsoMdlModel.isoNamespace): .array([])
+			])
+		}
+
+		#expect(throws: MdocValidationError.self) {
+			try IssuerSigned(cbor: cbor)
+		}
+	}
+
 	@Test func encodeDeviceResponse() throws {
 		let cborIn = try #require(try CBOR.decode(AnnexdTestData.d412.bytes))
 		let dr = try DeviceResponse(cbor: cborIn)
@@ -373,6 +415,27 @@ struct MdocDataModel18013Tests {
 		#expect(spec.extensions == nil)
 	}
 
+	@Test func decodeUseCaseRejectsEmptyDocumentSet() throws {
+		let cbor = CBOR.map([
+			.utf8String("mandatory"): .boolean(true),
+			.utf8String("documentSets"): .array([.array([])])
+		])
+
+		#expect(throws: MdocValidationError.self) {
+			try UseCase(cbor: cbor)
+		}
+	}
+
+	@Test func decodeDeviceRequestInfoRejectsEmptyUseCasesArray() throws {
+		let cbor = CBOR.map([
+			.utf8String("useCases"): .array([])
+		])
+
+		#expect(throws: MdocValidationError.self) {
+			try DeviceRequestInfo(cbor: cbor)
+		}
+	}
+
 	private func unsupportedVersionCBOR(
 		from bytes: [UInt8],
 		key: CBOR,
@@ -384,5 +447,33 @@ struct MdocDataModel18013Tests {
 		}
 		map[key] = .utf8String(version)
 		return .map(map)
+	}
+
+	private func mutatedTopLevelMapCBOR(
+		from bytes: [UInt8],
+		mutate: (inout OrderedDictionary<CBOR, CBOR>) throws -> Void
+	) throws -> CBOR {
+		let cbor = try #require(try CBOR.decode(bytes))
+		guard case .map(var map) = cbor else {
+			throw MdocValidationError.invalidCbor("test data")
+		}
+		try mutate(&map)
+		return .map(map)
+	}
+
+	private func mutatedIssuerSignedCBOR(
+		from responseBytes: [UInt8],
+		mutate: (inout OrderedDictionary<CBOR, CBOR>) throws -> Void
+	) throws -> CBOR {
+		let responseCbor = try #require(try CBOR.decode(responseBytes))
+		guard case .map(let responseMap) = responseCbor,
+			  case let .array(documents)? = responseMap[.utf8String("documents")],
+			  let firstDocument = documents.first,
+			  case .map(let documentMap) = firstDocument,
+			  case .map(var issuerSignedMap) = documentMap[.utf8String("issuerSigned")] else {
+			throw MdocValidationError.invalidCbor("test data")
+		}
+		try mutate(&issuerSignedMap)
+		return .map(issuerSignedMap)
 	}
 }

--- a/Tests/MdocDataModel18013Tests/MdocDataModel18013Tests.swift
+++ b/Tests/MdocDataModel18013Tests/MdocDataModel18013Tests.swift
@@ -69,7 +69,7 @@ struct MdocDataModel18013Tests {
 	}
 
     // test based on D.4.1.1 mdoc request section of the ISO/IEC FDIS 18013-5 document
-	@Test func decodeDeviceRequest() throws {
+    @Test func decodeDeviceRequest() throws {
 		let dr = try DeviceRequest(data: AnnexdTestData.d411.bytes)
 		let testItems = ["family_name", "document_number", "driving_privileges", "issue_date", "expiry_date", "portrait"].sorted()
         #expect(dr.version == "1.0")
@@ -83,6 +83,18 @@ struct MdocDataModel18013Tests {
 		let isoKeys: [IsoMdlModel.CodingKeys] = [.familyName, .documentNumber, .drivingPrivileges, .issueDate, .expiryDate, .portrait]
 		let dr3 = DeviceRequest(mdl: isoKeys, agesOver: [], intentToRetain: true)
 		#expect(dr3.docRequests.first?.itemsRequest.requestNameSpaces[IsoMdlModel.isoNamespace]?.elementIdentifiers.sorted() == testItems)
+	}
+
+	@Test func decodeDeviceRequestRejectsUnsupportedVersion() throws {
+		let cbor = try unsupportedVersionCBOR(
+			from: Self.AnnexdTestData.d411.bytes,
+			key: .utf8String("version"),
+			version: "1.9"
+		)
+
+		#expect(throws: MdocValidationError.self) {
+			try DeviceRequest(cbor: cbor)
+		}
 	}
 
 	@Test func decodeSampleDataResponse() throws {
@@ -219,6 +231,18 @@ struct MdocDataModel18013Tests {
 		#expect(model.familyName == "Doe")
 	}
 
+	@Test func decodeDeviceResponseRejectsUnsupportedVersion() throws {
+		let cbor = try unsupportedVersionCBOR(
+			from: Self.AnnexdTestData.d412.bytes,
+			key: .utf8String("version"),
+			version: "1.9"
+		)
+
+		#expect(throws: MdocValidationError.self) {
+			try DeviceResponse(cbor: cbor)
+		}
+	}
+
 	@Test func encodeDeviceResponse() throws {
 		let cborIn = try #require(try CBOR.decode(AnnexdTestData.d412.bytes))
 		let dr = try DeviceResponse(cbor: cborIn)
@@ -226,6 +250,18 @@ struct MdocDataModel18013Tests {
         // test if successfully encoded
         let dr2 = try DeviceResponse(cbor: cborDr)
         #expect(dr2.version == "1.0")
+	}
+
+	@Test func decodeDeviceEngagementRejectsUnsupportedVersion() throws {
+		let cbor = try unsupportedVersionCBOR(
+			from: Self.AnnexdTestData.d31.bytes,
+			key: .unsignedInt(0),
+			version: "1.9"
+		)
+
+		#expect(throws: MdocValidationError.self) {
+			try DeviceEngagement(cbor: cbor)
+		}
 	}
 
 	@Test func decodeDeviceAuthRejectsMutuallyExclusiveFields() throws {
@@ -335,5 +371,18 @@ struct MdocDataModel18013Tests {
 		#expect(spec.params["block_enc_hash"]?.intValue == 4096)
 		#expect(spec.params["block_enc_sig"]?.intValue == 2945)
 		#expect(spec.extensions == nil)
+	}
+
+	private func unsupportedVersionCBOR(
+		from bytes: [UInt8],
+		key: CBOR,
+		version: String
+	) throws -> CBOR {
+		let cbor = try #require(try CBOR.decode(bytes))
+		guard case .map(var map) = cbor else {
+			throw MdocValidationError.invalidCbor("test data")
+		}
+		map[key] = .utf8String(version)
+		return .map(map)
 	}
 }

--- a/Tests/MdocDataModel18013Tests/MdocDataModel18013Tests.swift
+++ b/Tests/MdocDataModel18013Tests/MdocDataModel18013Tests.swift
@@ -32,13 +32,13 @@ struct MdocDataModel18013Tests {
     @Test func decodeDE1() throws {
         let de = try DeviceEngagement(data: Self.AnnexdTestData.d31.bytes)
         #expect(de.version == "1.0")
-        #expect(de.deviceRetrievalMethods?.first == .ble(isBleServer: false, uuid: UUID(uuidString: "45EFEF74-2B2C-4837-A9A3-B0E1D05A6917")!))
+        #expect(de.deviceRetrievalMethods?.first == .ble(peripheralServerMode: false, uuid: UUID(uuidString: "45EFEF74-2B2C-4837-A9A3-B0E1D05A6917")!))
     }
 
     @Test func decodeDE2() throws {
         let de = try DeviceEngagement(data: Self.OtherTestData.deOnline.bytes)
         #expect(de.version == "1.0")
-        #expect(de.deviceRetrievalMethods?.first == .ble(isBleServer: true, uuid: UUID(uuidString: "0000D296-0000-1000-8000-00805F9B34FB")!))
+        #expect(de.deviceRetrievalMethods?.first == .ble(peripheralServerMode: true, uuid: UUID(uuidString: "0000D296-0000-1000-8000-00805F9B34FB")!))
         #expect(de.serverRetrievalOptions?.webAPI == ServerRetrievalOption(url: "https://api.pp.mobiledl.us/api/Iso18013", token: "eWqbX81BE0LaT1cumhgh"))
     }
 
@@ -149,7 +149,7 @@ struct MdocDataModel18013Tests {
 			)
 		)
 		#expect(mdlObj.familyName == "ANDERSSON")
-		printDisplayStrings(mdlObj.docClaims)
+		// printDisplayStrings(mdlObj.docClaims)
 	}
 
 	func printDisplayStrings(_ displayStrings: [DocClaim], level: Int = 0) {

--- a/Tests/MdocDataModel18013Tests/MdocDataModel18013Tests.swift
+++ b/Tests/MdocDataModel18013Tests/MdocDataModel18013Tests.swift
@@ -35,11 +35,22 @@ struct MdocDataModel18013Tests {
         #expect(de.deviceRetrievalMethods?.first == .ble(peripheralServerMode: false, uuid: UUID(uuidString: "45EFEF74-2B2C-4837-A9A3-B0E1D05A6917")!))
     }
 
-    @Test func decodeDE2() throws {
+
+    @Test("Decode DE with online retrieval method")
+     func decodeDeviceEngagementOnline() throws {
         let de = try DeviceEngagement(data: Self.OtherTestData.deOnline.bytes)
         #expect(de.version == "1.0")
         #expect(de.deviceRetrievalMethods?.first == .ble(peripheralServerMode: true, uuid: UUID(uuidString: "0000D296-0000-1000-8000-00805F9B34FB")!))
         #expect(de.serverRetrievalOptions?.webAPI == ServerRetrievalOption(url: "https://api.pp.mobiledl.us/api/Iso18013", token: "eWqbX81BE0LaT1cumhgh"))
+    }
+
+    @Test("Decode DE with offline retrieval methods")
+     func decodeDeviceEngagementOffline() throws {
+        let de = try DeviceEngagement(data: Self.OtherTestData.deOffline.bytes)
+        #expect(de.version == "1.0")
+		let retrievalMethods = try #require(de.deviceRetrievalMethods)
+		#expect(try #require(retrievalMethods.first) == .ble(peripheralServerMode: false, uuid: UUID(uuidString: "DEAA78C8-9E6B-9D3E-7C97-F272EFCE6B57")!))
+		#expect(try #require(retrievalMethods.dropFirst().first) == .ble(peripheralServerMode: true, uuid: UUID(uuidString: "DEAA78C8-9E6B-9D3E-7C97-F272EFCE6B57")!))
     }
 
     @Test func encodeDE() throws {

--- a/Tests/MdocDataModel18013Tests/MdocDataModel_TestData.swift
+++ b/Tests/MdocDataModel18013Tests/MdocDataModel_TestData.swift
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2023 European Commission
+Copyright (c) 2026 European Commission
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/Tests/MdocDataModel18013Tests/MdocDataModel_TestData.swift
+++ b/Tests/MdocDataModel18013Tests/MdocDataModel_TestData.swift
@@ -34,6 +34,7 @@ extension MdocDataModel18013Tests {
 
     enum OtherTestData {
         static let deOnline = Data(base64Encoded: "pABjMS4wAYIB2BhYS6QBAiABIVggE1J1aXu4P9WmTmQqBjpJA3SPiRqQD2oR/kTiCvD5kKwiWCA5lKH1NUsQjsGoFJXU/HGq9gEaIgihxHBLjc1cYAd3QgKBgwIBowD1AfQKUAAA0pYAABAAgAAAgF+bNPsDoWZ3ZWJBcGmDAXgnaHR0cHM6Ly9hcGkucHAubW9iaWxlZGwudXMvYXBpL0lzbzE4MDEzdGVXcWJYODFCRTBMYVQxY3VtaGdo")!
-		
+
+        static let deOffline = Data(base64URLEncoded: "owBjMS4wAYIB2BhYS6QBAiABIVggWArCVADDTdHDi0b9Z9sbjE6aWewxX2kCWvoNnUbfsqQiWCATW-AYzpyGws5peBd3frutln0Gi6WTNpYTGemx7Hc0oAKCgwIBowD0AfULUN6qeMiea50-fJfycu_Oa1eDAgGjAPUB9ApQ3qp4yJ5rnT58l_Jy785rVw")!
     }
 }

--- a/Tests/MdocDataModel18013Tests/TestExtensions.swift
+++ b/Tests/MdocDataModel18013Tests/TestExtensions.swift
@@ -1,0 +1,9 @@
+import Foundation
+
+extension Data {
+    /// init from local file (test-only helper)
+    init?(name: String, ext: String = "json", from bundle: Bundle = Bundle.main) {
+        guard let url = bundle.url(forResource: name, withExtension: ext) else { return nil }
+        try? self.init(contentsOf: url, options: .mappedIfSafe)
+    }
+}


### PR DESCRIPTION
This pull request addresses several issues by implementing date-time format validation in `ValidityInfo`, renaming the `id` field in `ZkSystemSpec` to `zkSystemId`, and updating `mandatoryElementCodingKeys` in `EuPidModel` to include `birth_place` and `nationality`. Additionally, it removes an unused initializer from the `Data` extension, eliminates the `qr` case from `DeviceRetrievalMethod`, enhances `DeviceAuth` to enforce mutually exclusive fields, and improves version validation across structures. Code readability has been enhanced by renaming variables and adding checks for non-empty arrays in CBOR decoding.

Fixes #102, #101, #99, #96, #95, #100, #98, #97, #103, #104