### PR TITLE
Refactor CoseKeyPrivate for lazy key loading

### DIFF
--- a/Sources/MdocDataModel18013/DeviceEngagement/CoseKey.swift
+++ b/Sources/MdocDataModel18013/DeviceEngagement/CoseKey.swift
@@ -43,10 +43,25 @@ public struct CoseKey: Equatable, Codable, Sendable {
 /// COSE_Key + private key
 public struct CoseKeyPrivate: Sendable {
 
-	public var key: CoseKey!
-    public var privateKeyId: String!
-    public var index: Int!
-    public var secureArea: (any SecureArea)!
+	private var cachedKey: CoseKey?
+    public var privateKeyId: String
+    public var index: Int
+    public var secureArea: (any SecureArea)
+	private var curve: CoseEcCurve
+
+	public var key: CoseKey {
+		mutating get async throws {
+			if let cachedKey {
+				return cachedKey
+			}
+			///guard let privateKeyId, let index, let curve else {
+			//	throw SecureAreaError("Cannot load public key: key reference is incomplete")
+			//}
+			let loadedKey = try await secureArea.getPublicKey(id: privateKeyId, index: index, curve: curve)
+			self.cachedKey = loadedKey
+			return loadedKey
+		}
+	}
 
 	/// Initialize with existing key in secure area
     public init(privateKeyId: String, index: Int, secureArea: any SecureArea, curve: CoseEcCurve) async throws {
@@ -54,30 +69,23 @@ public struct CoseKeyPrivate: Sendable {
 		self.privateKeyId = privateKeyId
         self.index = index
 		self.secureArea = secureArea
-		self.key = try await secureArea.getPublicKey(id: privateKeyId, index: index, curve: curve)
+		self.curve = curve
 	}
 
-    public init(secureArea: any SecureArea) {
-        self.secureArea = secureArea
-    }
-
-}
-
-extension CoseKeyPrivate {
-	// make new key
-    public mutating func makeKey(curve: CoseEcCurve) async throws {
-        let ephemeralKeyId = UUID().uuidString
+    public init(secureArea: any SecureArea, curve: CoseEcCurve)  async throws {
         index = 0
-        privateKeyId = ephemeralKeyId
+        privateKeyId = UUID().uuidString
+        self.secureArea = secureArea
+		self.curve = curve
         let createdKeys = try await secureArea.createKeyBatch(
-            id: ephemeralKeyId,
+            id: privateKeyId,
             credentialOptions: CredentialOptions(credentialPolicy: .rotateUse, batchSize: 1),
             keyOptions: KeyOptions(curve: curve)
         )
         guard let firstKey = createdKeys.first else {
             throw SecureAreaError("Secure area returned an empty key batch")
         }
-        self.key = firstKey
+		self.cachedKey = firstKey
 	}
 }
 

--- a/Sources/MdocDataModel18013/DeviceEngagement/CoseKey.swift
+++ b/Sources/MdocDataModel18013/DeviceEngagement/CoseKey.swift
@@ -64,7 +64,7 @@ public struct CoseKeyPrivate: Sendable {
 	}
 
 	/// Initialize with existing key in secure area
-    public init(privateKeyId: String, index: Int, secureArea: any SecureArea, curve: CoseEcCurve) async throws {
+    public init(privateKeyId: String, index: Int, secureArea: any SecureArea, curve: CoseEcCurve) {
         logger.info("Loading cose key private with id: \(privateKeyId)")
 		self.privateKeyId = privateKeyId
         self.index = index

--- a/Sources/MdocDataModel18013/DeviceEngagement/DeviceEngagement.swift
+++ b/Sources/MdocDataModel18013/DeviceEngagement/DeviceEngagement.swift
@@ -73,10 +73,8 @@ public struct DeviceEngagement: Sendable {
 	}
 
     public mutating func makePrivateKey(crv: CoseEcCurve, secureArea: any SecureArea) async throws {
-		var generatedPrivateKey = CoseKeyPrivate(secureArea: secureArea)
-		try await generatedPrivateKey.makeKey(curve: crv)
-		privateKey = generatedPrivateKey
-		security = Security(deviceKey: generatedPrivateKey.key)
+        privateKey = try await CoseKeyPrivate(secureArea: secureArea, curve: crv)
+		security = Security(deviceKey: try await privateKey!.key)
     }
 
 	public var supportsCentralClientMode: Bool {

--- a/Tests/MdocDataModel18013Tests/InMemoryP256SecureArea.swift
+++ b/Tests/MdocDataModel18013Tests/InMemoryP256SecureArea.swift
@@ -110,8 +110,6 @@ extension MdocDataModel18013.CoseKeyPrivate {
         let keyData = NSMutableData(bytes: [0x04], length: [0x04].count)
         keyData.append(Data(coseKey.x)); keyData.append(Data(coseKey.y));  keyData.append(Data(rd))
         sampleSA.x963Key = keyData as Data
-        self.init(secureArea: sampleSA)
-        self.privateKeyId = privateKeyId
-        self.index = 0
+        self.init(privateKeyId: privateKeyId, index: 0, secureArea: sampleSA, curve: .P256)
     }
 }


### PR DESCRIPTION
Implement lazy loading of keys in CoseKeyPrivate to improve efficiency and update DeviceEngagement for private key creation. This change enhances the handling of secure area keys by caching them and streamlining the key creation process.

Fixes wallet kit issue https://github.com/eu-digital-identity-wallet/eudi-lib-ios-wallet-kit/issues/351