### PR TITLE
Use KeyOptions for CoseKey creation

### DIFF
--- a/Sources/MdocDataModel18013/DeviceEngagement/CoseKey.swift
+++ b/Sources/MdocDataModel18013/DeviceEngagement/CoseKey.swift
@@ -72,15 +72,15 @@ public struct CoseKeyPrivate: Sendable {
 		self.curve = curve
 	}
 
-    public init(secureArea: any SecureArea, curve: CoseEcCurve)  async throws {
+    public init(secureArea: any SecureArea, keyOptions: KeyOptions)  async throws {
         index = 0
         privateKeyId = UUID().uuidString
         self.secureArea = secureArea
-		self.curve = curve
+        self.curve = keyOptions.curve
         let createdKeys = try await secureArea.createKeyBatch(
             id: privateKeyId,
             credentialOptions: CredentialOptions(credentialPolicy: .rotateUse, batchSize: 1),
-            keyOptions: KeyOptions(curve: curve)
+            keyOptions: keyOptions
         )
         guard let firstKey = createdKeys.first else {
             throw SecureAreaError("Secure area returned an empty key batch")

--- a/Sources/MdocDataModel18013/DeviceEngagement/DeviceEngagement.swift
+++ b/Sources/MdocDataModel18013/DeviceEngagement/DeviceEngagement.swift
@@ -78,8 +78,8 @@ public struct DeviceEngagement: Sendable {
 		try self.init(cbor: obj)
 	}
 
-    public mutating func makePrivateKey(crv: CoseEcCurve, secureArea: any SecureArea) async throws {
-        privateKey = try await CoseKeyPrivate(secureArea: secureArea, curve: crv)
+    public mutating func makePrivateKey(secureArea: any SecureArea, keyOptions: KeyOptions) async throws {
+        privateKey = try await CoseKeyPrivate(secureArea: secureArea, keyOptions: keyOptions)
 		security = Security(deviceKey: try await privateKey!.key)
     }
 


### PR DESCRIPTION
Enhance CoseKeyPrivate initialization to accept KeyOptions, allowing for richer key configuration. Update DeviceEngagement to forward KeyOptions when creating private keys. This improves flexibility in key management.