### PR TITLE
Expose DeviceKeyInfo.KeyAuthorizations and DeviceSigned.DeviceNameSpaces

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -18,7 +18,7 @@ let package = Package(
         .package(url: "https://github.com/SwiftyJSON/SwiftyJSON.git", from: "5.0.1"),
         .package(url: "https://github.com/apple/swift-log.git", from: "1.10.1"),
 		.package(url: "https://github.com/eu-digital-identity-wallet/SwiftCopyableMacro.git", from: "0.0.5"),
-		.package(url: "https://github.com/apple/swift-docc-plugin", from: "1.0.0"),
+		.package(url: "https://github.com/apple/swift-docc-plugin", from: "1.5.0"),
     ]
     ,
 

--- a/Sources/MdocDataModel18013/IssuerAuth/DeviceKeyInfo.swift
+++ b/Sources/MdocDataModel18013/IssuerAuth/DeviceKeyInfo.swift
@@ -27,8 +27,8 @@ typealias AuthorizedDataElements = [NameSpace: DataElementsArray]
 /// mdoc authentication public key and information related to this key.
 public struct DeviceKeyInfo:Sendable {
 	public let deviceKey: CoseKey
-	let keyAuthorizations: KeyAuthorizations?
-	let keyInfo: CBOR?
+	public let keyAuthorizations: KeyAuthorizations?
+	public let keyInfo: CBOR?
 
 	enum Keys: String {
 		case deviceKey
@@ -36,8 +36,10 @@ public struct DeviceKeyInfo:Sendable {
 		case keyInfo
 	}
 
-	public init(deviceKey: CoseKey) {
-		self.deviceKey = deviceKey; self.keyAuthorizations = nil; self.keyInfo = nil
+    public init(deviceKey: CoseKey, keyAuthorizations: KeyAuthorizations? = nil, keyInfo: CBOR? = nil) {
+		self.deviceKey = deviceKey;
+        self.keyAuthorizations = keyAuthorizations;
+        self.keyInfo = keyInfo
 	}
 }
 
@@ -66,7 +68,7 @@ extension DeviceKeyInfo: CBOREncodable {
 }
 
 /// Contains the elements the key may sign or MAC
-struct KeyAuthorizations: Sendable {
+public struct KeyAuthorizations: Sendable {
 	let nameSpaces: AuthorizedNameSpaces?
 	let dataElements: AuthorizedDataElements?
 
@@ -77,7 +79,7 @@ struct KeyAuthorizations: Sendable {
 }
 
 extension KeyAuthorizations: CBORDecodable {
-	init(cbor: CBOR) throws(MdocValidationError) {
+	public init(cbor: CBOR) throws(MdocValidationError) {
 		guard case let .map(cborMap) = cbor else { throw MdocValidationError.invalidCbor("key authorizations") }
 		var authorizedNameSpaces: AuthorizedNameSpaces? = nil
 		if case let .array(nameSpaceValues) = cborMap[Keys.nameSpaces] {

--- a/Sources/MdocDataModel18013/MdocResponse/DeviceSigned.swift
+++ b/Sources/MdocDataModel18013/MdocResponse/DeviceSigned.swift
@@ -21,7 +21,6 @@ import OrderedCollections
 /// Contains the mdoc authentication structure and the data elements protected by mdoc authentication
 public struct DeviceSigned: Sendable {
 	let nameSpaces: DeviceNameSpaces
-	let nameSpacesRawData: [UInt8]
 	let deviceAuth: DeviceAuth
 	//DeviceNameSpacesBytes = #6.24(bstr .cbor DeviceNameSpaces)
 	enum Keys: String {
@@ -29,9 +28,8 @@ public struct DeviceSigned: Sendable {
 		case deviceAuth
 	}
 
-	public init(deviceAuth: DeviceAuth) {
-		nameSpaces = DeviceNameSpaces(deviceNameSpaces: [:])
-		nameSpacesRawData = CBOR.map([:]).encode()
+    public init(deviceAuth: DeviceAuth, deviceNameSpaces: DeviceNameSpaces? = nil ) {
+		nameSpaces = deviceNameSpaces ?? DeviceNameSpaces(deviceNameSpaces: [:])
 		self.deviceAuth = deviceAuth
 	}
 }
@@ -49,14 +47,13 @@ extension DeviceSigned: CBORDecodable {
         nameSpaces = try DeviceNameSpaces(cbor: obj)
 		guard let cdu = m[Keys.deviceAuth] else { throw .missingField("DeviceSigned", Keys.deviceAuth.rawValue) }
 		deviceAuth = try DeviceAuth(cbor: cdu)
-		nameSpacesRawData = bs
 	}
 }
 
 extension DeviceSigned: CBOREncodable {
 	public func toCBOR(options: CBOROptions) -> CBOR {
 		var cbor = OrderedDictionary<CBOR, CBOR>()
-		cbor[.utf8String(Keys.nameSpaces.rawValue)] = nameSpacesRawData.taggedEncoded
+        cbor[.utf8String(Keys.nameSpaces.rawValue)] = nameSpaces.toCBOR(options: options).taggedEncoded
 		cbor[.utf8String(Keys.deviceAuth.rawValue)] = deviceAuth.toCBOR(options: options)
 		return .map(cbor)
 	}
@@ -81,6 +78,16 @@ extension DeviceNameSpaces: CBORDecodable {
 	}
 }
 
+extension DeviceNameSpaces: CBOREncodable {
+    public func toCBOR(options: CBOROptions) -> CBOR {
+        var cbor = OrderedDictionary<CBOR, CBOR>()
+        for (n, items) in deviceNameSpaces {
+            cbor[.utf8String(n)] = items.toCBOR(options: options)
+        }
+        return .map(cbor)
+    }
+}
+
 /// Contains the data element identifiers and values for a namespace
 public struct DeviceSignedItems: Sendable {
 	public let deviceSignedItems: [DataElementIdentifier: DataElementValue]
@@ -98,6 +105,16 @@ extension DeviceSignedItems: CBORDecodable {
 		guard !dsi.isEmpty else { throw .invalidCbor("device signed empty array") }
 		deviceSignedItems = dsi
 	}
+}
+
+extension DeviceSignedItems: CBOREncodable {
+    public func toCBOR(options: CBOROptions) -> CBOR {
+        var cbor = OrderedDictionary<CBOR, CBOR>()
+        for (key, value) in deviceSignedItems {
+            cbor[.utf8String(key)] = value
+        }
+        return .map(cbor)
+    }
 }
 
 

--- a/Sources/MdocDataModel18013/MdocResponse/DeviceSigned.swift
+++ b/Sources/MdocDataModel18013/MdocResponse/DeviceSigned.swift
@@ -61,59 +61,54 @@ extension DeviceSigned: CBOREncodable {
 
 /// Device data elements per namespac
 public struct DeviceNameSpaces: Sendable {
-	public let deviceNameSpaces: [NameSpace: DeviceSignedItems]
+	public let deviceNameSpaces: OrderedDictionary<NameSpace, DeviceSignedItems>
 	public subscript(ns: NameSpace) -> DeviceSignedItems? { deviceNameSpaces[ns] }
 }
 
 extension DeviceNameSpaces: CBORDecodable {
 	public init(cbor: CBOR) throws(MdocValidationError) {
 		guard case let .map(m) = cbor else { throw .invalidCbor("device signed") }
-		let dnsPairs = try m.map { (k: CBOR, v: CBOR) throws(MdocValidationError) -> (NameSpace, DeviceSignedItems)  in
-			guard case .utf8String(let ns) = k else { throw .invalidCbor("device signed") }
-			let deviceSignedItems = try DeviceSignedItems(cbor: v)
-			return (ns, deviceSignedItems)
+		var orderedDeviceSignedNamespaces = OrderedDictionary<NameSpace, DeviceSignedItems>()
+		for (k, v) in m {
+			guard case .utf8String(let ns) = k else { throw .invalidCbor("Invalid device signed namespace") }
+			orderedDeviceSignedNamespaces[ns] = try DeviceSignedItems(cbor: v)
 		}
-		let dsignItemsMap: [NameSpace : DeviceSignedItems] = Dictionary(dnsPairs, uniquingKeysWith: { (first, _) in first })
-		deviceNameSpaces = dsignItemsMap
+		deviceNameSpaces = orderedDeviceSignedNamespaces
 	}
 }
 
 extension DeviceNameSpaces: CBOREncodable {
     public func toCBOR(options: CBOROptions) -> CBOR {
-        var cbor = OrderedDictionary<CBOR, CBOR>()
-        for (n, items) in deviceNameSpaces {
-            cbor[.utf8String(n)] = items.toCBOR(options: options)
-        }
-        return .map(cbor)
+        .map(deviceNameSpaces.reduce(into: OrderedDictionary<CBOR, CBOR>()) { cbor, pair in
+            cbor[.utf8String(pair.key)] = pair.value.toCBOR(options: options)
+        })
     }
 }
 
 /// Contains the data element identifiers and values for a namespace
 public struct DeviceSignedItems: Sendable {
-	public let deviceSignedItems: [DataElementIdentifier: DataElementValue]
+	public let deviceSignedItems: OrderedDictionary<DataElementIdentifier, DataElementValue>
 	public subscript(ei: DataElementIdentifier) -> DataElementValue? { deviceSignedItems[ei] }
 }
 
 extension DeviceSignedItems: CBORDecodable {
 	public init(cbor: CBOR) throws(MdocValidationError) {
 		guard case let .map(m) = cbor else { throw .invalidCbor("device signed") }
-		let dsiPairs = try m.map { (k: CBOR, v: CBOR) throws(MdocValidationError) -> (DataElementIdentifier, DataElementValue) in
-			guard case .utf8String(let dei) = k else { throw .invalidCbor("device signed") }
-			return (dei,v)
+		var orderedDataElements = OrderedDictionary<DataElementIdentifier, DataElementValue>()
+		for (k, v) in m {
+			guard case .utf8String(let dei) = k else { throw .invalidCbor("Invalid device signed item") }
+			orderedDataElements[dei] = v
 		}
-		let dsi = Dictionary(dsiPairs, uniquingKeysWith: { (first, _) in first })
-		guard !dsi.isEmpty else { throw .invalidCbor("device signed empty array") }
-		deviceSignedItems = dsi
+		guard !orderedDataElements.isEmpty else { throw .invalidCbor("device signed empty array") }
+		deviceSignedItems = orderedDataElements
 	}
 }
 
 extension DeviceSignedItems: CBOREncodable {
     public func toCBOR(options: CBOROptions) -> CBOR {
-        var cbor = OrderedDictionary<CBOR, CBOR>()
-        for (key, value) in deviceSignedItems {
-            cbor[.utf8String(key)] = value
-        }
-        return .map(cbor)
+        .map(deviceSignedItems.reduce(into: OrderedDictionary<CBOR, CBOR>()) { cbor, pair in
+            cbor[.utf8String(pair.key)] = pair.value
+        })
     }
 }
 

--- a/Tests/MdocDataModel18013Tests/MdocDataModel18013Tests.swift
+++ b/Tests/MdocDataModel18013Tests/MdocDataModel18013Tests.swift
@@ -218,7 +218,9 @@ struct MdocDataModel18013Tests {
 		#expect(valueDigests1[0]!.toHexString().localizedUppercase == "75167333B47B6C2BFB86ECCC1F438CF57AF055371AC55E1E359E20F254ADCEBF")
 		#expect(valueDigests2.digestIDs.count == 4)
 		#expect(isoNS.count > 0)
-		#expect(doc.deviceSigned.nameSpacesRawData.count == 1); #expect(doc.deviceSigned.nameSpacesRawData[0] == 160) // {} A0 empty dic
+        #expect(doc.deviceSigned.nameSpaces.deviceNameSpaces.isEmpty);
+        let rawDeviceNameSpaces = doc.deviceSigned.nameSpaces.encode(options: CBOROptions())
+        #expect(rawDeviceNameSpaces.count == 1); #expect(rawDeviceNameSpaces[0] == 160)
 		#expect(doc.deviceSigned.deviceAuth.coseMacOrSignature.macAlgorithm == Cose.MacAlgorithm.hmac256)
 		#expect(doc.deviceSigned.deviceAuth.coseMacOrSignature.signature.bytes.toHexString().uppercased() == "E99521A85AD7891B806A07F8B5388A332D92C189A7BF293EE1F543405AE6824D")
         let d1 = dr.documents!.first!
@@ -332,7 +334,7 @@ struct MdocDataModel18013Tests {
 
   #if os(iOS)
     @Test func generateBLEengageQRCodeImage() async throws {
-        var de = try #require(DeviceEngagement(isBleServer: true))
+        var de = try #require(DeviceEngagement(supportsCentralClientMode: true, supportsPeripheralServerMode: true))
         try await de.makePrivateKey(crv: .P256, secureArea: InMemoryP256SecureArea(storage: DummySecureKeyStorage()))
         #expect(de.getQrCodePayload().count > 0)
         let strQR = de.qrCode
@@ -340,7 +342,7 @@ struct MdocDataModel18013Tests {
     }
 
     @Test func generateBLEengageQRCodePayload() async throws {
-        var de = try #require(DeviceEngagement(isBleServer: true))
+        var de = try #require(DeviceEngagement(supportsCentralClientMode: true, supportsPeripheralServerMode: true))
         try await de.makePrivateKey(crv: .P256, secureArea: InMemoryP256SecureArea(storage: DummySecureKeyStorage()))
         #expect(de.getQrCodePayload().count > 0)
     }


### PR DESCRIPTION
Hi,

I am looking at implementing Transaction Data for mso_mdoc credentials (https://github.com/eu-digital-identity-wallet/eudi-lib-ios-wallet-kit/issues/377).

I want to extend the getDeviceResponseToSend helper function (https://github.com/eu-digital-identity-wallet/eudi-lib-ios-iso18013-data-transfer/blob/main/Sources/MdocDataTransfer18013/MdocHelpers.swift#L228). As far as I understand from the specifications, I need to validate the KeyAuthorizations from the credentials DeviceKeyInfo and write the processed transaction data into DeviceNameSpaces of the DeviceSigned object.

I therefore propose that these properties are exposes as public and that they are allow to be set in their constructors.