### PR TITLE
Make KeyAuthorizations properties public

### DIFF
--- a/Sources/MdocDataModel18013/IssuerAuth/DeviceKeyInfo.swift
+++ b/Sources/MdocDataModel18013/IssuerAuth/DeviceKeyInfo.swift
@@ -20,9 +20,9 @@ import Foundation
 import SwiftCBOR
 import OrderedCollections
 
-typealias AuthorizedNameSpaces = [NameSpace]
-typealias DataElementsArray = [DataElementIdentifier]
-typealias AuthorizedDataElements = [NameSpace: DataElementsArray]
+public typealias AuthorizedNameSpaces = [NameSpace]
+public typealias DataElementsArray = [DataElementIdentifier]
+public typealias AuthorizedDataElements = [NameSpace: DataElementsArray]
 
 /// mdoc authentication public key and information related to this key.
 public struct DeviceKeyInfo:Sendable {
@@ -69,13 +69,18 @@ extension DeviceKeyInfo: CBOREncodable {
 
 /// Contains the elements the key may sign or MAC
 public struct KeyAuthorizations: Sendable {
-	let nameSpaces: AuthorizedNameSpaces?
-	let dataElements: AuthorizedDataElements?
+	public let nameSpaces: AuthorizedNameSpaces?
+	public let dataElements: AuthorizedDataElements?
 
 	enum Keys: String {
 		case nameSpaces
 		case dataElements
 	}
+    
+    public init(nameSpaces: AuthorizedNameSpaces? = nil, dataElements: AuthorizedDataElements? = nil) {
+        self.nameSpaces = nameSpaces;
+        self.dataElements = dataElements;
+    }
 }
 
 extension KeyAuthorizations: CBORDecodable {

--- a/Sources/MdocDataModel18013/MdocResponse/DeviceSigned.swift
+++ b/Sources/MdocDataModel18013/MdocResponse/DeviceSigned.swift
@@ -63,6 +63,10 @@ extension DeviceSigned: CBOREncodable {
 public struct DeviceNameSpaces: Sendable {
 	public let deviceNameSpaces: OrderedDictionary<NameSpace, DeviceSignedItems>
 	public subscript(ns: NameSpace) -> DeviceSignedItems? { deviceNameSpaces[ns] }
+    
+    public init(deviceNameSpaces: OrderedDictionary<NameSpace, DeviceSignedItems>) {
+        self.deviceNameSpaces = deviceNameSpaces
+    }
 }
 
 extension DeviceNameSpaces: CBORDecodable {
@@ -89,6 +93,10 @@ extension DeviceNameSpaces: CBOREncodable {
 public struct DeviceSignedItems: Sendable {
 	public let deviceSignedItems: OrderedDictionary<DataElementIdentifier, DataElementValue>
 	public subscript(ei: DataElementIdentifier) -> DataElementValue? { deviceSignedItems[ei] }
+    
+    public init(deviceSignedItems: OrderedDictionary<DataElementIdentifier, DataElementValue>) {
+        self.deviceSignedItems = deviceSignedItems
+    }
 }
 
 extension DeviceSignedItems: CBORDecodable {

--- a/Tests/MdocDataModel18013Tests/MdocDataModel18013Tests.swift
+++ b/Tests/MdocDataModel18013Tests/MdocDataModel18013Tests.swift
@@ -335,7 +335,11 @@ struct MdocDataModel18013Tests {
   #if os(iOS)
     @Test func generateBLEengageQRCodeImage() async throws {
         var de = try #require(DeviceEngagement(supportsCentralClientMode: true, supportsPeripheralServerMode: true))
-        try await de.makePrivateKey(crv: .P256, secureArea: InMemoryP256SecureArea(storage: DummySecureKeyStorage()))
+        try await de
+            .makePrivateKey(
+                secureArea: InMemoryP256SecureArea(storage: DummySecureKeyStorage()),
+                keyOptions: KeyOptions(curve: .P256)
+            )
         #expect(de.getQrCodePayload().count > 0)
         let strQR = de.qrCode
 		#expect(DeviceEngagement.getQrCodeImage(qrCode: strQR, inputCorrectionLevel: .m) != nil)
@@ -343,7 +347,10 @@ struct MdocDataModel18013Tests {
 
     @Test func generateBLEengageQRCodePayload() async throws {
         var de = try #require(DeviceEngagement(supportsCentralClientMode: true, supportsPeripheralServerMode: true))
-        try await de.makePrivateKey(crv: .P256, secureArea: InMemoryP256SecureArea(storage: DummySecureKeyStorage()))
+        try await de.makePrivateKey(
+            secureArea: InMemoryP256SecureArea(storage: DummySecureKeyStorage()),
+            keyOptions: KeyOptions(curve: .P256)
+        )
         #expect(de.getQrCodePayload().count > 0)
     }
   #endif


### PR DESCRIPTION
Make KeyAuthorizations properties public.

Changes needed to implement transaction data for mso_mdoc credentials (https://github.com/eu-digital-identity-wallet/eudi-lib-ios-wallet-kit/issues/377)