### PR TITLE
Expose ReaderAuth certificate chain and update SwiftCBOR dependency

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,13 +1,13 @@
 {
-  "originHash" : "fdf233abd3a4449777663b976061081ff25c2af97c399424fc0e08cf83c4624e",
+  "originHash" : "33047f58dafa180395ab8f0af751fece7025d1d2bc58a4c3ffa58a4f8bf7e328",
   "pins" : [
     {
       "identity" : "swift-collections",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-collections.git",
       "state" : {
-        "revision" : "671108c96644956dddcd89dd59c203dcdb36cec7",
-        "version" : "1.1.4"
+        "revision" : "a0cb0954ecb21e4e31b0070e6ed5674e8556685a",
+        "version" : "1.6.0"
       }
     },
     {
@@ -51,8 +51,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/niscy-eudiw/SwiftCBOR.git",
       "state" : {
-        "revision" : "a663e7a6bd50d2224223ed60622b531b18499dd0",
-        "version" : "0.6.4"
+        "revision" : "e8fef8613a4c32b150885fec8f32c2ebfe0501c4",
+        "version" : "0.6.5"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -14,7 +14,7 @@ let package = Package(
             targets: ["MdocDataModel18013"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/niscy-eudiw/SwiftCBOR.git", from: "0.6.4"),
+        .package(url: "https://github.com/niscy-eudiw/SwiftCBOR.git", from: "0.6.5"),
         .package(url: "https://github.com/SwiftyJSON/SwiftyJSON.git", from: "5.0.1"),
         .package(url: "https://github.com/apple/swift-log.git", from: "1.10.1"),
 		.package(url: "https://github.com/eu-digital-identity-wallet/SwiftCopyableMacro.git", from: "0.0.5"),

--- a/Sources/MdocDataModel18013/MdocRequest/ReaderAuth.swift
+++ b/Sources/MdocDataModel18013/MdocRequest/ReaderAuth.swift
@@ -22,7 +22,7 @@ public struct ReaderAuth: Sendable {
 	/// encoded data
     let coseSign1: Cose
 	/// one or more certificates
-	let x5chain: [[UInt8]]
+	public let x5chain: [[UInt8]]
 }
 
 extension ReaderAuth: CBORDecodable {


### PR DESCRIPTION
Make the `ReaderAuth.x5chain` public for easier access to the certificate chain and update the SwiftCBOR dependency to version 0.6.5 to incorporate the latest fixes and improvements.