### PR TITLE
Add 'type' property to Cose and make properties public in Status and ReaderAuth

### DIFF
--- a/Sources/MdocDataModel18013/Cose.swift
+++ b/Sources/MdocDataModel18013/Cose.swift
@@ -77,11 +77,13 @@ extension Cose {
 		public enum Headers : Int {
 			case keyId = 4
 			case algorithm = 1
+            case typ = 16
 		}
 
-		public let rawHeader : CBOR?
-		public let keyId : [UInt8]?
-		public let algorithm : UInt64?
+		public let rawHeader: CBOR?
+		public let keyId: [UInt8]?
+		public let algorithm: UInt64?
+        public let type: String?
 
 		// MARK: - Initializers
 		/// Initialize from CBOR
@@ -89,16 +91,18 @@ extension Cose {
 		public init?(fromBytestring cbor: CBOR){
 			guard let cborMap = cbor.decodeBytestring()?.asMap(),
 				  let alg = cborMap[Headers.algorithm]?.asUInt64() else {
-				self.init(alg: nil, isNegativeAlg: nil, keyId: nil, rawHeader: cbor)
+                self.init(alg: nil, isNegativeAlg: nil, keyId: nil, type: nil, rawHeader: cbor)
 				return
 			}
-			self.init(alg: alg, isNegativeAlg: nil, keyId: cborMap[Headers.keyId]?.asBytes(), rawHeader: cbor)
+            let type = cborMap[Headers.typ]?.asString()
+            self.init(alg: alg, isNegativeAlg: nil, keyId: cborMap[Headers.keyId]?.asBytes(), type: type, rawHeader: cbor)
 		}
 
-		public init?(alg: UInt64?, isNegativeAlg: Bool?, keyId: [UInt8]?, rawHeader : CBOR? = nil){
+        public init?(alg: UInt64?, isNegativeAlg: Bool?, keyId: [UInt8]?, type: String? = nil, rawHeader : CBOR? = nil){
 			guard alg != nil || rawHeader != nil else { return nil }
 			self.algorithm = alg
 			self.keyId = keyId
+            self.type = type
 			func algCbor() -> CBOR { isNegativeAlg! ? .negativeInt(alg!) : .unsignedInt(alg!) }
 			self.rawHeader = rawHeader ?? .byteString(CBOR.map([.unsignedInt(UInt64(Headers.algorithm.rawValue)) : algCbor()]).encode())
 		}

--- a/Sources/MdocDataModel18013/IssuerAuth/StatusList.swift
+++ b/Sources/MdocDataModel18013/IssuerAuth/StatusList.swift
@@ -16,7 +16,7 @@ limitations under the License.
 import Foundation
 import SwiftCBOR
 
-public struct Status: Decodable {
+public struct Status: Decodable, Sendable {
 	public let statusList: StatusList
 
 	enum CodingKeys: String, CodingKey {

--- a/Sources/MdocDataModel18013/IssuerAuth/StatusList.swift
+++ b/Sources/MdocDataModel18013/IssuerAuth/StatusList.swift
@@ -17,7 +17,7 @@ import Foundation
 import SwiftCBOR
 
 public struct Status: Decodable {
-	let statusList: StatusList
+	public let statusList: StatusList
 
 	enum CodingKeys: String, CodingKey {
 		case statusList = "status_list"

--- a/Sources/MdocDataModel18013/MdocRequest/ReaderAuth.swift
+++ b/Sources/MdocDataModel18013/MdocRequest/ReaderAuth.swift
@@ -20,7 +20,7 @@ import SwiftCBOR
 /// Reader authentication structure encoded as Cose Sign1
 public struct ReaderAuth: Sendable {
 	/// encoded data
-    let coseSign1: Cose
+    public let coseSign1: Cose
 	/// one or more certificates
 	public let x5chain: [[UInt8]]
 }


### PR DESCRIPTION
Introduce a 'type' property in the Cose struct and conform the Status struct to the Sendable protocol. Additionally, make properties in Status and ReaderAuth public for better accessibility.