### PR TITLE
Enhance key access control and authentication context

### DIFF
--- a/Sources/MdocDataModel18013/SecureArea/KeyBatchInfo.swift
+++ b/Sources/MdocDataModel18013/SecureArea/KeyBatchInfo.swift
@@ -18,20 +18,18 @@ import Foundation
 
 public struct KeyBatchInfo: Codable, Sendable {
     
-    public init(secureAreaName: String?, crv: CoseEcCurve, usedCounts: [Int], credentialPolicy: CredentialPolicy, keyPurpose: [KeyPurpose]? = nil, attestation: KeyAttestation? = nil) {
-        self.secureAreaName = secureAreaName
-        self.crv = crv
+    public init(keyOptions: KeyOptions?, usedCounts: [Int], credentialPolicy: CredentialPolicy, keyPurpose: [KeyPurpose]? = nil, attestation: KeyAttestation? = nil) {
+        self.keyOptions = keyOptions
         self.usedCounts = usedCounts
         self.credentialPolicy = credentialPolicy
         self.keyPurpose = keyPurpose
         self.attestation = attestation
     }
-    /// public key data
-    public var crv: CoseEcCurve
+    /// Options used to create the keys.
+    public var keyOptions: KeyOptions?
     /// Tasks for which key can be used.
     public var keyPurpose: [KeyPurpose]? = KeyPurpose.allCases
     public var attestation: KeyAttestation?
-    public let secureAreaName: String?
     public var usedCounts: [Int]
     public let credentialPolicy: CredentialPolicy
 
@@ -47,8 +45,7 @@ public struct KeyBatchInfo: Codable, Sendable {
     }
     
     public init(previous: KeyBatchInfo, keyIndex: Int) {
-        self.secureAreaName = previous.secureAreaName
-        self.crv = previous.crv
+        self.keyOptions = previous.keyOptions
         self.credentialPolicy = previous.credentialPolicy
         var newUsedCounts = previous.usedCounts
         newUsedCounts[keyIndex] = previous.usedCounts[keyIndex] + 1

--- a/Sources/MdocDataModel18013/SecureArea/KeyOptions.swift
+++ b/Sources/MdocDataModel18013/SecureArea/KeyOptions.swift
@@ -17,7 +17,7 @@ limitations under the License.
 import Foundation
 
 /// Key options
-public struct KeyOptions: Codable, Sendable {
+public struct KeyOptions: Codable, Sendable, Equatable {
     public init(curve: CoseEcCurve = .P256, secureAreaName: String? = nil, accessProtection: KeyAccessProtection? = nil, accessControl: KeyAccessControl? = nil, keyPurposes: [KeyPurpose]? = KeyPurpose.allCases, additionalOptions: Data? = nil) {
         self.curve = curve
         self.secureAreaName = secureAreaName

--- a/Sources/MdocDataModel18013/SecureArea/KeyOptions.swift
+++ b/Sources/MdocDataModel18013/SecureArea/KeyOptions.swift
@@ -76,25 +76,44 @@ public enum KeyAccessProtection: Int, Codable, CaseIterable, Sendable {
         }
     }
 }
+/// Codable conformance for the native flags, so ``KeyAccessControl`` can synthesise its own.
+extension SecAccessControlCreateFlags: @retroactive Codable {}
+
 /// Key access control settings
 ///
 /// Using these settings you can check for the presence of the authorized user at the very last minute before retrieving login credentials from the keychain. This helps secure the private key even if the user hands the device in an unlocked state to someone else.
-public struct KeyAccessControl: OptionSet, Codable, Sendable {
-    public init(rawValue: Int) {
-        self.rawValue = rawValue
-    }
-    public let rawValue: Int
-
+///
+/// The named cases are mutually exclusive user authentication constraints. Use ``custom(_:)`` to pass any other
+/// combination of keychain flags through verbatim, for example a biometry constraint with a passcode fallback:
+/// `.custom([.biometryCurrentSet, .or, .devicePasscode])`.
+public enum KeyAccessControl: Codable, Equatable, Sendable {
     /// Require user presence policy using biometry or Passcode
-    public static let requireUserPresence = KeyAccessControl(rawValue: 1 << 0)
-    /// Require application provided password for additional data encryption key generation
-    public static let requireApplicationPassword = KeyAccessControl(rawValue: 1 << 1)
+    case requireUserPresence
+    /// Require any enrolled biometry, without allowing passcode fallback
+    case requireBiometryAny
+    /// Require current biometry set without allowing passcode fallback or newly enrolled biometrics
+    case requireBiometryCurrentSet
+    /// Native keychain flags, used as given
+    case custom(SecAccessControlCreateFlags)
 
+    /// Creates the case matching the given native flags, falling back to ``custom(_:)`` for anything else
+    public init(flags: SecAccessControlCreateFlags) {
+        switch flags {
+        case SecAccessControlCreateFlags.userPresence: self = .requireUserPresence
+        case SecAccessControlCreateFlags.biometryAny: self = .requireBiometryAny
+        case SecAccessControlCreateFlags.biometryCurrentSet: self = .requireBiometryCurrentSet
+        default: self = .custom(flags)
+        }
+    }
+
+    /// flags to use for the kSecAttrAccessControl attribute
     public var flags: SecAccessControlCreateFlags {
-        var result: SecAccessControlCreateFlags = []
-        if contains(.requireUserPresence) { result.insert(.userPresence) }
-        if contains(.requireApplicationPassword) { result.insert(.applicationPassword) }
-        return result
+        switch self {
+        case .requireUserPresence: SecAccessControlCreateFlags.userPresence
+        case .requireBiometryAny: SecAccessControlCreateFlags.biometryAny
+        case .requireBiometryCurrentSet: SecAccessControlCreateFlags.biometryCurrentSet
+        case .custom(let flags): flags
+        }
     }
 }
 #endif

--- a/Sources/MdocDataModel18013/SecureArea/KeyOptions.swift
+++ b/Sources/MdocDataModel18013/SecureArea/KeyOptions.swift
@@ -87,6 +87,8 @@ extension SecAccessControlCreateFlags: @retroactive Codable {}
 /// combination of keychain flags through verbatim, for example a biometry constraint with a passcode fallback:
 /// `.custom([.biometryCurrentSet, .or, .devicePasscode])`.
 public enum KeyAccessControl: Codable, Equatable, Sendable {
+    // no access control
+    case empty
     /// Require user presence policy using biometry or Passcode
     case requireUserPresence
     /// Require any enrolled biometry, without allowing passcode fallback
@@ -109,6 +111,7 @@ public enum KeyAccessControl: Codable, Equatable, Sendable {
     /// flags to use for the kSecAttrAccessControl attribute
     public var flags: SecAccessControlCreateFlags {
         switch self {
+        case .empty: []
         case .requireUserPresence: SecAccessControlCreateFlags.userPresence
         case .requireBiometryAny: SecAccessControlCreateFlags.biometryAny
         case .requireBiometryCurrentSet: SecAccessControlCreateFlags.biometryCurrentSet

--- a/Sources/MdocDataModel18013/SecureArea/SecureArea.swift
+++ b/Sources/MdocDataModel18013/SecureArea/SecureArea.swift
@@ -46,11 +46,13 @@ public protocol SecureArea: Actor {
     /// delete key info
     func deleteKeyInfo(id: String) async throws
     /// compute signature, return raw representation
-    func signature(id: String, index: Int, algorithm: SigningAlgorithm, dataToSign: Data, unlockData: Data?) async throws -> Data
+    /// compute signature using a reusable local authentication context when supported
+    func signature(id: String, index: Int, algorithm: SigningAlgorithm, dataToSign: Data, unlockData: Data?, authenticationContext: ThreadSafeAuthContext) async throws -> Data
     /// make key-agreement (shared secret) with other public key (used for encryption and mac computations)
-    func keyAgreement(id: String, index: Int, publicKey: CoseKey, unlockData: Data?) async throws -> SharedSecret
+    /// uses a reusable local authentication context when the private key requires user presence
+    func keyAgreement(id: String, index: Int, publicKey: CoseKey, unlockData: Data?, authenticationContext: ThreadSafeAuthContext) async throws -> SharedSecret
     /// returns information about the key with the given id and the curve of the key
-    func getInfoAndCurve(id: String) async throws -> ([String:Data], CoseEcCurve) 
+    func getInfoAndCurve(id: String) async throws -> ([String:Data], CoseEcCurve)
     /// returns information about the key with the given id
     func getKeyBatchInfo(id: String) async throws -> KeyBatchInfo
     /// return the storage instance

--- a/Sources/MdocDataModel18013/SecureArea/SecureKeyStorage.swift
+++ b/Sources/MdocDataModel18013/SecureArea/SecureKeyStorage.swift
@@ -19,8 +19,8 @@ import Foundation
 public protocol SecureKeyStorage: Actor {
     // read key public info
     func readKeyInfo(id: String) async throws -> [String: Data]
-    // read key sensitive info (may trigger biometric or password checks)
-    func readKeyData(id: String, index: Int) async throws -> [String: Data]
+    // read key sensitive info using a reusable thread-safe local authentication context
+    func readKeyData(id: String, index: Int, authenticationContext: ThreadSafeAuthContext) async throws -> [String: Data]
     // save key public info
     func writeKeyInfo(id: String, dict: [String: Data]) async throws
     // save key data batch info
@@ -28,5 +28,5 @@ public protocol SecureKeyStorage: Actor {
     // delete key data
     func deleteKeyBatch(id: String, startIndex: Int, batchSize: Int) async throws
     // delete key info
-    func deleteKeyInfo(id: String) async throws 
+    func deleteKeyInfo(id: String) async throws
 }

--- a/Sources/MdocDataModel18013/SecureArea/ThreadSafeAuthContext.swift
+++ b/Sources/MdocDataModel18013/SecureArea/ThreadSafeAuthContext.swift
@@ -1,0 +1,50 @@
+/*
+Copyright (c) 2026 European Commission
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import Foundation
+import os
+@preconcurrency import LocalAuthentication
+
+public final class ThreadSafeAuthContext: @unchecked Sendable {
+    private let lock: OSAllocatedUnfairLock<LAContext>
+
+    public init(context: LAContext = LAContext()) {
+        lock = OSAllocatedUnfairLock(initialState: context)
+    }
+
+    public func invalidate() {
+        lock.withLock { context in
+            context.invalidate()
+        }
+    }
+
+    public func canEvaluatePolicy(_ policy: LAPolicy, error: NSErrorPointer) -> Bool {
+        lock.withLockUnchecked { context in
+            context.canEvaluatePolicy(policy, error: error)
+        }
+    }
+
+    public func evaluatePolicy(_ policy: LAPolicy, localizedReason: String) async throws -> Bool {
+        let context = lock.withLock { $0 }
+        return try await context.evaluatePolicy(policy, localizedReason: localizedReason)
+    }
+
+    public func withLAContext<T>(_ body: (LAContext) throws -> T) rethrows -> T? {
+        try lock.withLockUnchecked { context in
+            try body(context)
+        }
+    }
+}

--- a/Tests/MdocDataModel18013Tests/InMemoryP256SecureArea.swift
+++ b/Tests/MdocDataModel18013Tests/InMemoryP256SecureArea.swift
@@ -66,16 +66,26 @@ public actor InMemoryP256SecureArea: SecureArea {
      }
 
     public func signature(id: String, index: Int, algorithm: MdocDataModel18013.SigningAlgorithm, dataToSign: Data, unlockData: Data?) throws -> Data {
+        try signature(
+            id: id,
+            index: index,
+            algorithm: algorithm,
+            dataToSign: dataToSign,
+            unlockData: unlockData,
+            authenticationContext: ThreadSafeAuthContext()
+        )
+    }
+
+    public func signature(id: String, index: Int, algorithm: MdocDataModel18013.SigningAlgorithm, dataToSign: Data, unlockData: Data?, authenticationContext: ThreadSafeAuthContext) throws -> Data {
         let signature = try key.signature(for: dataToSign)
         return signature.rawRepresentation
     }
 
-    public func keyAgreement(id: String, index: Int, publicKey: MdocDataModel18013.CoseKey, unlockData: Data?) throws -> SharedSecret {
+    public func keyAgreement(id: String, index: Int, publicKey: MdocDataModel18013.CoseKey, unlockData: Data?, authenticationContext: ThreadSafeAuthContext) throws -> SharedSecret {
         let puk256 = try P256.KeyAgreement.PublicKey(x963Representation: publicKey.x963Representation)
         let prk256 = try P256.KeyAgreement.PrivateKey(x963Representation: key.x963Representation)
         let sharedSecret = try prk256.sharedSecretFromKeyAgreement(with: puk256)
         return sharedSecret
-
     }
 
     public func getKeyBatchInfo(id: String) throws -> MdocDataModel18013.KeyBatchInfo {
@@ -89,6 +99,10 @@ public actor DummySecureKeyStorage: MdocDataModel18013.SecureKeyStorage {
     }
 
     public func readKeyData(id: String, index: Int) throws -> [String : Data] {
+        [:]
+    }
+
+    public func readKeyData(id: String, index: Int, authenticationContext: ThreadSafeAuthContext) throws -> [String : Data] {
         [:]
     }
 

--- a/Tests/MdocDataModel18013Tests/InMemoryP256SecureArea.swift
+++ b/Tests/MdocDataModel18013Tests/InMemoryP256SecureArea.swift
@@ -79,7 +79,7 @@ public actor InMemoryP256SecureArea: SecureArea {
     }
 
     public func getKeyBatchInfo(id: String) throws -> MdocDataModel18013.KeyBatchInfo {
-        KeyBatchInfo(secureAreaName: Self.name, crv: .P256, usedCounts: [0], credentialPolicy: .rotateUse)
+        KeyBatchInfo(keyOptions: KeyOptions(curve: .P256, secureAreaName: Self.name), usedCounts: [0], credentialPolicy: .rotateUse)
     }
 }
 

--- a/Tests/MdocDataModel18013Tests/KeyAccessControlTests.swift
+++ b/Tests/MdocDataModel18013Tests/KeyAccessControlTests.swift
@@ -1,0 +1,110 @@
+import Foundation
+import MdocDataModel18013
+import Security
+import Testing
+
+@Suite("Key Access Control Tests")
+struct KeyAccessControlTests {
+
+    /// Every named case and the keychain flags it must produce.
+    static let namedCases: [(accessControl: KeyAccessControl, expected: SecAccessControlCreateFlags)] = [
+        (.requireUserPresence, .userPresence),
+        (.requireBiometryAny, .biometryAny),
+        (.requireBiometryCurrentSet, .biometryCurrentSet),
+    ]
+
+    @Test("named cases map to the native flag bits")
+    func testNamedCasesMapToNativeFlagBits() {
+        #expect(SecAccessControlCreateFlags.userPresence.rawValue == 1 << 0)
+        #expect(KeyAccessControl.requireUserPresence.flags == .userPresence)
+
+        #expect(SecAccessControlCreateFlags.biometryAny.rawValue == 1 << 1)
+        #expect(KeyAccessControl.requireBiometryAny.flags == .biometryAny)
+
+        #expect(SecAccessControlCreateFlags.biometryCurrentSet.rawValue == 1 << 3)
+        #expect(KeyAccessControl.requireBiometryCurrentSet.flags == .biometryCurrentSet)
+    }
+
+    @Test("init(flags:) recognises the flags of every named case", arguments: namedCases)
+    func testInitFromFlagsRecognisesNamedCases(namedCase: (accessControl: KeyAccessControl, expected: SecAccessControlCreateFlags)) {
+        #expect(KeyAccessControl(flags: namedCase.expected) == namedCase.accessControl)
+        #expect(KeyAccessControl(flags: namedCase.accessControl.flags) == namedCase.accessControl)
+    }
+
+    @Test("custom passes its flags through unchanged", arguments: [
+        SecAccessControlCreateFlags([]),
+        [.biometryCurrentSet, .or, .devicePasscode],
+        [.biometryCurrentSet, .and, .applicationPassword],
+        [.devicePasscode],
+        [.watch],
+        SecAccessControlCreateFlags(rawValue: 1 << 20), // a bit this SDK does not name at all
+    ])
+    func testCustomPassesFlagsThrough(flags: SecAccessControlCreateFlags) {
+        #expect(KeyAccessControl.custom(flags).flags == flags)
+    }
+
+    @Test("flags that match no named case become custom")
+    func testUnrecognisedFlagsBecomeCustom() {
+        let fallback: SecAccessControlCreateFlags = [.biometryCurrentSet, .or, .devicePasscode]
+        #expect(KeyAccessControl(flags: fallback) == .custom(fallback))
+        #expect(KeyAccessControl(flags: []) == .custom([]))
+        // no bit is silently dropped on the way back out
+        #expect(KeyAccessControl(flags: fallback).flags == fallback)
+    }
+
+    @Test("custom holding a single named flag is equivalent to that named case")
+    func testCustomWithNamedFlagIsEquivalent() {
+        // .custom is not == the named case, but both produce the same keychain flags and normalise to the same value
+        #expect(KeyAccessControl.custom(.biometryCurrentSet).flags == KeyAccessControl.requireBiometryCurrentSet.flags)
+        #expect(KeyAccessControl(flags: KeyAccessControl.custom(.biometryCurrentSet).flags) == .requireBiometryCurrentSet)
+    }
+
+    @Test("named cases round-trip through Codable", arguments: namedCases)
+    func testNamedCasesRoundTripThroughCodable(namedCase: (accessControl: KeyAccessControl, expected: SecAccessControlCreateFlags)) throws {
+        let decoded = try roundTrip(namedCase.accessControl)
+
+        #expect(decoded == namedCase.accessControl)
+        #expect(decoded.flags == namedCase.expected)
+    }
+
+    @Test("custom round-trips through Codable")
+    func testCustomRoundTripsThroughCodable() throws {
+        let accessControl = KeyAccessControl.custom([.biometryCurrentSet, .or, .devicePasscode])
+
+        #expect(try roundTrip(accessControl) == accessControl)
+    }
+
+    private func roundTrip(_ accessControl: KeyAccessControl) throws -> KeyAccessControl {
+        let data = try JSONEncoder().encode([accessControl])
+        return try JSONDecoder().decode([KeyAccessControl].self, from: data)[0]
+    }
+}
+
+// a simple OptionSet to test the remove and insert methods
+@Suite("ShippingOptions Tests")
+struct ShippingOptionsTests {
+
+    struct ShippingOptions: OptionSet {
+        let rawValue: Int
+
+        static let nextDay    = ShippingOptions(rawValue: 1 << 0)
+        static let secondDay  = ShippingOptions(rawValue: 1 << 1)
+        static let priority   = ShippingOptions(rawValue: 1 << 2)
+        static let standard   = ShippingOptions(rawValue: 1 << 3)
+
+        static let express: ShippingOptions = [.nextDay, .secondDay]
+        static let all: ShippingOptions = [.express, .priority, .standard]
+    }
+
+    @Test("remove returns the removed option and mutates the set")
+    func testRemoveOption() {
+        var options: ShippingOptions = [.secondDay, .priority]
+        let (bool, inserted) = options.insert(.priority)
+        #expect(bool == false)
+        #expect(inserted == .priority)
+        let priorityOption = options.remove(.priority)
+        #expect(priorityOption == .priority)
+        #expect(options == [.secondDay])
+        #expect(!options.contains(.priority))
+    }
+}


### PR DESCRIPTION
Introduce new `KeyAccessControl` enum cases and an empty option to represent keys without access-control requirements. Update `KeyBatchInfo` initialization to utilize `KeyOptions`, and enhance protocols to support a reusable `ThreadSafeAuthContext` for authentication. This improves the overall security and usability of key management operations.

Fixes #129